### PR TITLE
ESO-2: Updates default operator image name to match with CI configs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ endif
 # This is useful for CI or a project to utilize a specific version of the operator-sdk toolkit.
 OPERATOR_SDK_VERSION ?= v1.39.0
 # Image URL to use all building/pushing image targets
-IMG ?= controller:latest
+IMG ?= openshift.io/external-secrets-operator:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.31.0
 

--- a/bundle/manifests/external-secrets-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/external-secrets-operator.clusterserviceversion.yaml
@@ -21,7 +21,7 @@ metadata:
     categories: Security
     console.openshift.io/disable-operand-delete: "true"
     containerImage: ""
-    createdAt: "2025-05-14T12:04:01Z"
+    createdAt: "2025-05-20T08:13:26Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -240,7 +240,7 @@ spec:
                 - --health-probe-bind-address=:8081
                 command:
                 - /bin/external-secrets-operator
-                image: controller:latest
+                image: openshift.io/external-secrets-operator:latest
                 livenessProbe:
                   httpGet:
                     path: /healthz

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: controller
+  newName: openshift.io/external-secrets-operator
   newTag: latest

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -54,7 +54,7 @@ spec:
         args:
           - --leader-elect
           - --health-probe-bind-address=:8081
-        image: controller:latest
+        image: openshift.io/external-secrets-operator:latest
         name: manager
         securityContext:
           allowPrivilegeEscalation: false


### PR DESCRIPTION
PR is for updating the default operator image name in configs and Makefile to match with the CI configs, where the image is built and is used for replacing the default operator image.