### PR TITLE
NO-JIRA: Adds new fields to CSV, new make target for git check and auto-generated files from prev commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -370,3 +370,8 @@ verify: vet fmt golangci-lint verify-bindata verify-bindata-assets verify-genera
 ## update the relevant data based on new changes.
 .PHONY: update
 update: generate manifests update-operand-manifests update-bindata
+
+## checks for any uncommitted changes.
+.PHONY: check-git-diff
+check-git-diff: manifests generate update-operand-manifests bundle
+	./hack/check-git-diff-clean.sh

--- a/bundle/manifests/external-secrets-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/external-secrets-operator.clusterserviceversion.yaml
@@ -21,7 +21,7 @@ metadata:
     categories: Security
     console.openshift.io/disable-operand-delete: "true"
     containerImage: ""
-    createdAt: "2025-05-23T05:31:24Z"
+    createdAt: "2025-05-26T10:26:33Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -86,8 +86,8 @@ spec:
       version: v1beta1
     - description: |-
         ExternalSecrets describes configuration and information about the managed external-secrets
-        deployment. The name must be `cluster` to make ExternalSecrets a singleton that is, to
-        allow only one instance of ExternalSecrets per cluster.
+        deployment. The name must be `cluster` as ExternalSecrets is a singleton,
+        allowing only one instance per cluster.
 
         When an ExternalSecrets is created, a new deployment is created which manages the
         external-secrets and keeps it in the desired state.
@@ -237,10 +237,28 @@ spec:
               containers:
               - args:
                 - --metrics-bind-address=:8443
+                - --v=2
                 - --leader-elect
                 - --health-probe-bind-address=:8081
                 command:
                 - /bin/external-secrets-operator
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: external-secrets-operator
+                - name: OPERATOR_IMAGE_VERSION
+                  value: 0.1.0
+                - name: RELATED_IMAGE_EXTERNAL_SECRETS
+                  value: oci.external-secrets.io/external-secrets/external-secrets:v0.14.0
+                - name: OPERAND_EXTERNAL_SECRETS_IMAGE_VERSION
+                  value: 0.14.0
                 image: openshift.io/external-secrets-operator:latest
                 livenessProbe:
                   httpGet:
@@ -304,4 +322,7 @@ spec:
   minKubeVersion: 1.32.0
   provider:
     name: Red Hat, Inc.
+  relatedImages:
+  - image: oci.external-secrets.io/external-secrets/external-secrets:v0.14.0
+    name: external-secrets
   version: 0.1.0

--- a/bundle/manifests/external-secrets.io_clusterexternalsecrets.yaml
+++ b/bundle/manifests/external-secrets.io_clusterexternalsecrets.yaml
@@ -2,7 +2,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: external-secrets/external-secrets-webhook
     controller-gen.kubebuilder.io/version: v0.17.1
   creationTimestamp: null
   labels:

--- a/bundle/manifests/external-secrets.io_clustersecretstores.yaml
+++ b/bundle/manifests/external-secrets.io_clustersecretstores.yaml
@@ -2,7 +2,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: external-secrets/external-secrets-webhook
     controller-gen.kubebuilder.io/version: v0.17.1
   creationTimestamp: null
   labels:

--- a/bundle/manifests/external-secrets.io_externalsecrets.yaml
+++ b/bundle/manifests/external-secrets.io_externalsecrets.yaml
@@ -2,7 +2,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: external-secrets/external-secrets-webhook
     controller-gen.kubebuilder.io/version: v0.17.1
   creationTimestamp: null
   labels:

--- a/bundle/manifests/external-secrets.io_pushsecrets.yaml
+++ b/bundle/manifests/external-secrets.io_pushsecrets.yaml
@@ -2,7 +2,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: external-secrets/external-secrets-webhook
     controller-gen.kubebuilder.io/version: v0.17.1
   creationTimestamp: null
   labels:

--- a/bundle/manifests/external-secrets.io_secretstores.yaml
+++ b/bundle/manifests/external-secrets.io_secretstores.yaml
@@ -2,7 +2,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: external-secrets/external-secrets-webhook
     controller-gen.kubebuilder.io/version: v0.17.1
   creationTimestamp: null
   labels:

--- a/bundle/manifests/generators.external-secrets.io_acraccesstokens.yaml
+++ b/bundle/manifests/generators.external-secrets.io_acraccesstokens.yaml
@@ -2,7 +2,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: external-secrets/external-secrets-webhook
     controller-gen.kubebuilder.io/version: v0.17.1
   creationTimestamp: null
   labels:

--- a/bundle/manifests/generators.external-secrets.io_clustergenerators.yaml
+++ b/bundle/manifests/generators.external-secrets.io_clustergenerators.yaml
@@ -2,7 +2,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: external-secrets/external-secrets-webhook
     controller-gen.kubebuilder.io/version: v0.17.1
   creationTimestamp: null
   labels:

--- a/bundle/manifests/generators.external-secrets.io_ecrauthorizationtokens.yaml
+++ b/bundle/manifests/generators.external-secrets.io_ecrauthorizationtokens.yaml
@@ -2,7 +2,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: external-secrets/external-secrets-webhook
     controller-gen.kubebuilder.io/version: v0.17.1
   creationTimestamp: null
   labels:

--- a/bundle/manifests/generators.external-secrets.io_gcraccesstokens.yaml
+++ b/bundle/manifests/generators.external-secrets.io_gcraccesstokens.yaml
@@ -2,7 +2,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: external-secrets/external-secrets-webhook
     controller-gen.kubebuilder.io/version: v0.17.1
   creationTimestamp: null
   labels:

--- a/bundle/manifests/generators.external-secrets.io_generatorstates.yaml
+++ b/bundle/manifests/generators.external-secrets.io_generatorstates.yaml
@@ -2,7 +2,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: external-secrets/external-secrets-webhook
     controller-gen.kubebuilder.io/version: v0.17.1
   creationTimestamp: null
   labels:

--- a/bundle/manifests/generators.external-secrets.io_githubaccesstokens.yaml
+++ b/bundle/manifests/generators.external-secrets.io_githubaccesstokens.yaml
@@ -2,7 +2,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: external-secrets/external-secrets-webhook
     controller-gen.kubebuilder.io/version: v0.17.1
   creationTimestamp: null
   labels:

--- a/bundle/manifests/generators.external-secrets.io_grafanas.yaml
+++ b/bundle/manifests/generators.external-secrets.io_grafanas.yaml
@@ -2,7 +2,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: external-secrets/external-secrets-webhook
     controller-gen.kubebuilder.io/version: v0.17.1
   creationTimestamp: null
   labels:

--- a/bundle/manifests/generators.external-secrets.io_passwords.yaml
+++ b/bundle/manifests/generators.external-secrets.io_passwords.yaml
@@ -2,7 +2,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: external-secrets/external-secrets-webhook
     controller-gen.kubebuilder.io/version: v0.17.1
   creationTimestamp: null
   labels:

--- a/bundle/manifests/generators.external-secrets.io_quayaccesstokens.yaml
+++ b/bundle/manifests/generators.external-secrets.io_quayaccesstokens.yaml
@@ -2,7 +2,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: external-secrets/external-secrets-webhook
     controller-gen.kubebuilder.io/version: v0.17.1
   creationTimestamp: null
   labels:

--- a/bundle/manifests/generators.external-secrets.io_stssessiontokens.yaml
+++ b/bundle/manifests/generators.external-secrets.io_stssessiontokens.yaml
@@ -2,7 +2,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: external-secrets/external-secrets-webhook
     controller-gen.kubebuilder.io/version: v0.17.1
   creationTimestamp: null
   labels:

--- a/bundle/manifests/generators.external-secrets.io_uuids.yaml
+++ b/bundle/manifests/generators.external-secrets.io_uuids.yaml
@@ -2,7 +2,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: external-secrets/external-secrets-webhook
     controller-gen.kubebuilder.io/version: v0.17.1
   creationTimestamp: null
   labels:

--- a/bundle/manifests/generators.external-secrets.io_vaultdynamicsecrets.yaml
+++ b/bundle/manifests/generators.external-secrets.io_vaultdynamicsecrets.yaml
@@ -2,7 +2,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: external-secrets/external-secrets-webhook
     controller-gen.kubebuilder.io/version: v0.17.1
   creationTimestamp: null
   labels:

--- a/bundle/manifests/generators.external-secrets.io_webhooks.yaml
+++ b/bundle/manifests/generators.external-secrets.io_webhooks.yaml
@@ -2,7 +2,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: external-secrets/external-secrets-webhook
     controller-gen.kubebuilder.io/version: v0.17.1
   creationTimestamp: null
   labels:

--- a/bundle/manifests/operator.openshift.io_externalsecrets.yaml
+++ b/bundle/manifests/operator.openshift.io_externalsecrets.yaml
@@ -19,8 +19,8 @@ spec:
       openAPIV3Schema:
         description: |-
           ExternalSecrets describes configuration and information about the managed external-secrets
-          deployment. The name must be `cluster` to make ExternalSecrets a singleton that is, to
-          allow only one instance of ExternalSecrets per cluster.
+          deployment. The name must be `cluster` as ExternalSecrets is a singleton,
+          allowing only one instance per cluster.
 
           When an ExternalSecrets is created, a new deployment is created which manages the
           external-secrets and keeps it in the desired state.
@@ -1178,8 +1178,8 @@ spec:
                           issuerRef:
                             description: |-
                               issuerRef contains details to the referenced object used for
-                              obtaining the certificates. When issuerRef.Kind is Issuer, it must exist in the
-                              .spec.istioCSRConfig.istio.namespace.
+                              obtaining the certificates. It must exist in the external-secrets
+                              namespace if not using a cluster-scoped cert-manager issuer.
                             properties:
                               group:
                                 description: Group of the resource being referred
@@ -1197,11 +1197,6 @@ spec:
                             x-kubernetes-validations:
                             - message: issuerRef is immutable once set
                               rule: self == oldSelf
-                            - message: kind must be either 'Issuer' or 'ClusterIssuer'
-                              rule: self.kind.lowerAscii() == 'issuer' || self.kind.lowerAscii()
-                                == 'clusterissuer'
-                            - message: group must be 'cert-manager.io'
-                              rule: self.group.lowerAscii() == 'cert-manager.io'
                         required:
                         - issuerRef
                         type: object
@@ -1223,7 +1218,7 @@ spec:
             properties:
               conditions:
                 description: conditions holds information of the current state of
-                  the istio-csr agent deployment.
+                  deployment.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.

--- a/bundle/manifests/operator.openshift.io_externalsecretsmanagers.yaml
+++ b/bundle/manifests/operator.openshift.io_externalsecretsmanagers.yaml
@@ -19,12 +19,12 @@ spec:
       openAPIV3Schema:
         description: |-
           ExternalSecretsManager describes configuration and information about the deployments managed by
-          the operator. The name must be `cluster` to make ExternalSecretsManager a singleton that is, to
-          allow only one instance of ExternalSecretsManager per cluster.
+          the external-secrets-operator. The name must be `cluster` as this is a singleton object allowing
+          only one instance of ExternalSecretsManager per cluster.
 
-          ExternalSecretsManager is mainly for configuring the global options and enabling the features, which
+          It is mainly for configuring the global options and enabling optional features, which
           serves as a common/centralized config for managing multiple controllers of the operator. The object
-          will be created during the operator installation.
+          is automatically created during the operator installation.
         properties:
           apiVersion:
             description: |-
@@ -44,17 +44,21 @@ spec:
           metadata:
             type: object
           spec:
-            description: spec is the specification of the desired behavior of the
-              ExternalSecretsManager.
+            description: spec is the specification of the desired behavior
             properties:
               features:
-                description: features is for enabling the optional features.
+                description: features is for enabling the optional operator features.
                 items:
-                  description: Feature is for enabling the optional features.
+                  description: |-
+                    Feature is for enabling the optional features.
+                    Feature is for enabling the optional features.
                   properties:
                     enabled:
+                      description: enabled determines if feature should be turned
+                        on.
                       type: boolean
                     name:
+                      description: name of the optional feature.
                       type: string
                   required:
                   - enabled
@@ -62,8 +66,9 @@ spec:
                   type: object
                 type: array
               globalConfig:
-                description: globalConfig is for configuring the external-secrets-operator
-                  behavior.
+                description: |-
+                  globalConfig is for configuring the behavior of deployments that are managed
+                  by external secrets-operator.
                 properties:
                   affinity:
                     description: |-
@@ -1124,11 +1129,13 @@ spec:
                 type: object
             type: object
           status:
-            description: status is the most recently observed status of the ExternalSecretsManager.
+            description: |-
+              status is the most recently observed status of controllers used by
+              External Secrets Operator.
             properties:
               conditions:
                 description: conditions holds information of the current state of
-                  the istio-csr agent deployment.
+                  deployment.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.

--- a/cmd/external-secrets-operator/main.go
+++ b/cmd/external-secrets-operator/main.go
@@ -35,6 +35,9 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
+	zaplog "go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
 	operatorv1alpha1 "github.com/openshift/external-secrets-operator/api/v1alpha1"
 	"github.com/openshift/external-secrets-operator/pkg/controller"
 	// +kubebuilder:scaffold:imports
@@ -59,6 +62,7 @@ func main() {
 	var secureMetrics bool
 	var enableHTTP2 bool
 	var tlsOpts []func(*tls.Config)
+	var logLevel int
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -69,8 +73,13 @@ func main() {
 		"If set, the metrics endpoint is served securely via HTTPS. Use --metrics-secure=false to use HTTP instead.")
 	flag.BoolVar(&enableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
+	flag.IntVar(&logLevel, "v", 1, "operator log verbosity")
+
 	opts := zap.Options{
 		Development: true,
+		ZapOpts:     []zaplog.Option{zaplog.AddCaller()},
+		TimeEncoder: zapcore.ISO8601TimeEncoder,
+		Level:       zaplog.NewAtomicLevelAt(zapcore.Level(logLevel)),
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()

--- a/config/crd/bases/operator.openshift.io_externalsecrets.yaml
+++ b/config/crd/bases/operator.openshift.io_externalsecrets.yaml
@@ -19,8 +19,8 @@ spec:
       openAPIV3Schema:
         description: |-
           ExternalSecrets describes configuration and information about the managed external-secrets
-          deployment. The name must be `cluster` to make ExternalSecrets a singleton that is, to
-          allow only one instance of ExternalSecrets per cluster.
+          deployment. The name must be `cluster` as ExternalSecrets is a singleton,
+          allowing only one instance per cluster.
 
           When an ExternalSecrets is created, a new deployment is created which manages the
           external-secrets and keeps it in the desired state.
@@ -1178,8 +1178,8 @@ spec:
                           issuerRef:
                             description: |-
                               issuerRef contains details to the referenced object used for
-                              obtaining the certificates. When issuerRef.Kind is Issuer, it must exist in the
-                              .spec.istioCSRConfig.istio.namespace.
+                              obtaining the certificates. It must exist in the external-secrets
+                              namespace if not using a cluster-scoped cert-manager issuer.
                             properties:
                               group:
                                 description: Group of the resource being referred
@@ -1197,11 +1197,6 @@ spec:
                             x-kubernetes-validations:
                             - message: issuerRef is immutable once set
                               rule: self == oldSelf
-                            - message: kind must be either 'Issuer' or 'ClusterIssuer'
-                              rule: self.kind.lowerAscii() == 'issuer' || self.kind.lowerAscii()
-                                == 'clusterissuer'
-                            - message: group must be 'cert-manager.io'
-                              rule: self.group.lowerAscii() == 'cert-manager.io'
                         required:
                         - issuerRef
                         type: object
@@ -1223,7 +1218,7 @@ spec:
             properties:
               conditions:
                 description: conditions holds information of the current state of
-                  the istio-csr agent deployment.
+                  deployment.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.

--- a/config/crd/bases/operator.openshift.io_externalsecretsmanagers.yaml
+++ b/config/crd/bases/operator.openshift.io_externalsecretsmanagers.yaml
@@ -19,12 +19,12 @@ spec:
       openAPIV3Schema:
         description: |-
           ExternalSecretsManager describes configuration and information about the deployments managed by
-          the operator. The name must be `cluster` to make ExternalSecretsManager a singleton that is, to
-          allow only one instance of ExternalSecretsManager per cluster.
+          the external-secrets-operator. The name must be `cluster` as this is a singleton object allowing
+          only one instance of ExternalSecretsManager per cluster.
 
-          ExternalSecretsManager is mainly for configuring the global options and enabling the features, which
+          It is mainly for configuring the global options and enabling optional features, which
           serves as a common/centralized config for managing multiple controllers of the operator. The object
-          will be created during the operator installation.
+          is automatically created during the operator installation.
         properties:
           apiVersion:
             description: |-
@@ -44,17 +44,21 @@ spec:
           metadata:
             type: object
           spec:
-            description: spec is the specification of the desired behavior of the
-              ExternalSecretsManager.
+            description: spec is the specification of the desired behavior
             properties:
               features:
-                description: features is for enabling the optional features.
+                description: features is for enabling the optional operator features.
                 items:
-                  description: Feature is for enabling the optional features.
+                  description: |-
+                    Feature is for enabling the optional features.
+                    Feature is for enabling the optional features.
                   properties:
                     enabled:
+                      description: enabled determines if feature should be turned
+                        on.
                       type: boolean
                     name:
+                      description: name of the optional feature.
                       type: string
                   required:
                   - enabled
@@ -62,8 +66,9 @@ spec:
                   type: object
                 type: array
               globalConfig:
-                description: globalConfig is for configuring the external-secrets-operator
-                  behavior.
+                description: |-
+                  globalConfig is for configuring the behavior of deployments that are managed
+                  by external secrets-operator.
                 properties:
                   affinity:
                     description: |-
@@ -1124,11 +1129,13 @@ spec:
                 type: object
             type: object
           status:
-            description: status is the most recently observed status of the ExternalSecretsManager.
+            description: |-
+              status is the most recently observed status of controllers used by
+              External Secrets Operator.
             properties:
               conditions:
                 description: conditions holds information of the current state of
-                  the istio-csr agent deployment.
+                  deployment.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -52,8 +52,26 @@ spec:
       - command:
         - /bin/external-secrets-operator
         args:
+          - --v=2
           - --leader-elect
           - --health-probe-bind-address=:8081
+        env:
+          - name: WATCH_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.annotations['olm.targetNamespaces']
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: OPERATOR_NAME
+            value: external-secrets-operator
+          - name: OPERATOR_IMAGE_VERSION
+            value: 0.1.0
+          - name: RELATED_IMAGE_EXTERNAL_SECRETS
+            value: oci.external-secrets.io/external-secrets/external-secrets:v0.14.0
+          - name: OPERAND_EXTERNAL_SECRETS_IMAGE_VERSION
+            value: 0.14.0
         image: openshift.io/external-secrets-operator:latest
         name: manager
         securityContext:

--- a/config/manifests/bases/external-secrets-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/external-secrets-operator.clusterserviceversion.yaml
@@ -113,8 +113,8 @@ spec:
       version: v1alpha1
     - description: |-
         ExternalSecrets describes configuration and information about the managed external-secrets
-        deployment. The name must be `cluster` to make ExternalSecrets a singleton that is, to
-        allow only one instance of ExternalSecrets per cluster.
+        deployment. The name must be `cluster` as ExternalSecrets is a singleton,
+        allowing only one instance per cluster.
 
         When an ExternalSecrets is created, a new deployment is created which manages the
         external-secrets and keeps it in the desired state.

--- a/hack/check-git-diff-clean.sh
+++ b/hack/check-git-diff-clean.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# Ignore any expected automated changes like the timestamp update in clusterserviceversion file.
+ignore_expected_changes() {
+	csv_filename="bundle/manifests/external-secrets-operator.clusterserviceversion.yaml"
+	diff=$(git diff --no-ext-diff --unified=0 ${csv_filename} | egrep "^\+" | grep -Ev "createdAt|clusterserviceversion")
+	if [[ -z ${diff} ]]; then
+		git checkout ${csv_filename}
+	fi
+}
+
+##############################################
+###############  MAIN  #######################
+##############################################
+
+# update the git index
+git update-index -q --ignore-submodules --refresh
+
+ignore_expected_changes
+
+# git add all files, so that even untracked files are counted.
+git add . && git diff-index --cached --ignore-submodules --name-status --exit-code HEAD
+if [[ $? -ne 0 ]]; then
+	echo -e "\n-- ERROR -- There are uncommitted changes after running verify target. Please commit the changes.\n"
+	exit 1
+fi
+
+exit 0
+


### PR DESCRIPTION
PR has following changes:
- Adds new make target `check-git-diff` to check no auto-generated files are missed in the commit.
- Adds uncommitted auto-generated files from previous PRs.
- Adds new fields in operator CSV for operator and operand version, log level for operator.

**TODO: Include `check-git-diff` target in the verify target.**
- Adding it to `verify` target causes failures like [here](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_external-secrets-operator/14/pull-ci-openshift-external-secrets-operator-main-verify/1926953688627154944) which needs to be debugged and fixed.