### PR TITLE
ESO-50: Add controller to manage annotations on the external-secrets CRD

### DIFF
--- a/api/v1alpha1/conditions.go
+++ b/api/v1alpha1/conditions.go
@@ -21,6 +21,16 @@ const (
 	//   - Failed
 	//   - Ready: operand successfully deployed and ready
 	Ready string = "Ready"
+
+	// UpdateAnnotation is the condition type used to inform status of
+	// updating the annotations.
+	//   Status:
+	//   - True
+	//   - False
+	//   Reason:
+	//   - Completed
+	//   - Failed
+	UpdateAnnotation string = "UpdateAnnotation"
 )
 
 const (
@@ -29,4 +39,6 @@ const (
 	ReasonReady string = "Ready"
 
 	ReasonInProgress string = "Progressing"
+
+	ReasonCompleted string = "Completed"
 )

--- a/cmd/external-secrets-operator/main.go
+++ b/cmd/external-secrets-operator/main.go
@@ -24,6 +24,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	crdv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -52,6 +53,7 @@ func init() {
 	utilruntime.Must(corev1.AddToScheme(scheme))
 	utilruntime.Must(rbacv1.AddToScheme(scheme))
 	utilruntime.Must(certmanagerv1.AddToScheme(scheme))
+	utilruntime.Must(crdv1.AddToScheme(scheme))
 
 	utilruntime.Must(operatorv1alpha1.AddToScheme(scheme))
 	// +kubebuilder:scaffold:scheme

--- a/pkg/controller/common/utils.go
+++ b/pkg/controller/common/utils.go
@@ -8,6 +8,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	crdv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -36,6 +37,9 @@ func init() {
 		panic(err)
 	}
 	if err := webhook.AddToScheme(scheme); err != nil {
+		panic(err)
+	}
+	if err := crdv1.AddToScheme(scheme); err != nil {
 		panic(err)
 	}
 }

--- a/pkg/controller/commontest/utils.go
+++ b/pkg/controller/commontest/utils.go
@@ -1,0 +1,46 @@
+package commontest
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	operatorv1alpha1 "github.com/openshift/external-secrets-operator/api/v1alpha1"
+)
+
+const (
+	// TestExternalSecretsResourceName is the name for ExternalSecrets test CR.
+	TestExternalSecretsResourceName = "cluster"
+
+	// TestExternalSecretsImageName is the sample image name for external-secrets operand.
+	TestExternalSecretsImageName = "registry.redhat.io/external-secrets-operator/external-secrets-operator-rhel9"
+
+	// TestExternalSecretsNamespace is the sample namespace name for external-secrets deployment.
+	TestExternalSecretsNamespace = "test-external-secrets"
+
+	// TestCRDName can be used for sample CRD resources.
+	TestCRDName = "test-crd"
+)
+
+var (
+	// TestClientError is the error to return for client failure scenarios.
+	TestClientError = fmt.Errorf("test client error")
+)
+
+// TestExternalSecrets returns a sample ExternalSecrets object.
+func TestExternalSecrets() *operatorv1alpha1.ExternalSecrets {
+	return &operatorv1alpha1.ExternalSecrets{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: TestExternalSecretsResourceName,
+		},
+	}
+}
+
+// TestExternalSecretsManager returns a sample ExternalSecretsManager object.
+func TestExternalSecretsManager() *operatorv1alpha1.ExternalSecretsManager {
+	return &operatorv1alpha1.ExternalSecretsManager{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: TestExternalSecretsResourceName,
+		},
+	}
+}

--- a/pkg/controller/crd_annotator/controller.go
+++ b/pkg/controller/crd_annotator/controller.go
@@ -1,0 +1,325 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crd_annotator
+
+import (
+	"context"
+	"fmt"
+
+	crdv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/types"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/util/retry"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/go-logr/logr"
+
+	operatorv1alpha1 "github.com/openshift/external-secrets-operator/api/v1alpha1"
+	operatorclient "github.com/openshift/external-secrets-operator/pkg/controller/client"
+	"github.com/openshift/external-secrets-operator/pkg/controller/common"
+)
+
+const (
+	ControllerName = "crd-annotator"
+
+	// requestEnqueueLabelKey is the label key name used for filtering reconcile
+	// events to include only the resources created by the controller.
+	requestEnqueueLabelKey = "external-secrets.io/component"
+
+	// requestEnqueueLabelValue is the label value used for filtering reconcile
+	// events to include only the resources created by the controller.
+	requestEnqueueLabelValue = "controller"
+
+	// reconcileObjectIdentifier is for identifying the object for which reconcile event
+	// is received, based on which a specific action will be taken.
+	reconcileObjectIdentifier = "external-secrets-obj"
+)
+
+// Reconciler reconciles metadata on the managed CRDs.
+type Reconciler struct {
+	operatorclient.CtrlClient
+	ctx context.Context
+	log logr.Logger
+}
+
+func NewClient(m manager.Manager) (operatorclient.CtrlClient, error) {
+	c, err := BuildCustomClient(m)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build custom client: %w", err)
+	}
+	return &operatorclient.CtrlClientImpl{
+		Client: c,
+	}, nil
+}
+
+// New is for building the reconciler instance consumed by the Reconcile method.
+func New(mgr ctrl.Manager) (*Reconciler, error) {
+	r := &Reconciler{
+		ctx: context.Background(),
+		log: ctrl.Log.WithName(ControllerName),
+	}
+	c, err := NewClient(mgr)
+	if err != nil {
+		return nil, err
+	}
+	r.CtrlClient = c
+	return r, nil
+}
+
+// BuildCustomClient creates a custom client with a custom cache of required objects.
+// The corresponding informers receive events for objects matching label criteria.
+func BuildCustomClient(mgr ctrl.Manager) (client.Client, error) {
+	managedResourceLabelReq, _ := labels.NewRequirement(requestEnqueueLabelKey, selection.Equals, []string{requestEnqueueLabelValue})
+	managedResourceLabelReqSelector := labels.NewSelector().Add(*managedResourceLabelReq)
+
+	customCacheOpts := cache.Options{
+		HTTPClient: mgr.GetHTTPClient(),
+		Scheme:     mgr.GetScheme(),
+		Mapper:     mgr.GetRESTMapper(),
+		ByObject: map[client.Object]cache.ByObject{
+			&crdv1.CustomResourceDefinition{}: {
+				Label: managedResourceLabelReqSelector,
+			},
+			&operatorv1alpha1.ExternalSecrets{}: {},
+		},
+		ReaderFailOnMissingInformer: true,
+	}
+	customCache, err := cache.New(mgr.GetConfig(), customCacheOpts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build custom cache: %w", err)
+	}
+	if _, err = customCache.GetInformer(context.Background(), &crdv1.CustomResourceDefinition{}); err != nil {
+		return nil, err
+	}
+	if _, err = customCache.GetInformer(context.Background(), &operatorv1alpha1.ExternalSecrets{}); err != nil {
+		return nil, err
+	}
+
+	err = mgr.Add(customCache)
+	if err != nil {
+		return nil, err
+	}
+
+	customClient, err := client.New(mgr.GetConfig(), client.Options{
+		HTTPClient: mgr.GetHTTPClient(),
+		Scheme:     mgr.GetScheme(),
+		Mapper:     mgr.GetRESTMapper(),
+		Cache: &client.CacheOptions{
+			Reader: customCache,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return customClient, nil
+}
+
+// SetupWithManager is for creating a controller instance with predicates and event filters.
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	mapFunc := func(ctx context.Context, obj client.Object) []reconcile.Request {
+		r.log.V(4).Info("received reconcile event", "object", fmt.Sprintf("%T", obj), "name", obj.GetName(), "namespace", obj.GetNamespace())
+
+		var objName string
+		objLabels := obj.GetLabels()
+		if objLabels != nil {
+			if objLabels[requestEnqueueLabelKey] == requestEnqueueLabelValue {
+				objName = obj.GetName()
+			}
+		}
+		if obj.GetObjectKind().GroupVersionKind().GroupKind().String() ==
+			(&operatorv1alpha1.ExternalSecrets{}).GetObjectKind().GroupVersionKind().GroupKind().String() {
+			objName = reconcileObjectIdentifier
+		}
+		if objName != "" {
+			return []reconcile.Request{
+				{
+					NamespacedName: types.NamespacedName{
+						Name: objName,
+					},
+				},
+			}
+		}
+
+		r.log.V(4).Info("object not of interest, ignoring reconcile event", "object", fmt.Sprintf("%T", obj), "name", obj.GetName(), "namespace", obj.GetNamespace())
+		return []reconcile.Request{}
+	}
+
+	// predicate function to ignore events for objects not managed by controller.
+	managedResources := predicate.NewPredicateFuncs(func(object client.Object) bool {
+		return object.GetLabels() != nil && object.GetLabels()[requestEnqueueLabelKey] == requestEnqueueLabelValue
+	})
+	managedResourcePredicate := builder.WithPredicates(managedResources, predicate.AnnotationChangedPredicate{})
+
+	return ctrl.NewControllerManagedBy(mgr).
+		Named(ControllerName).
+		WatchesMetadata(&crdv1.CustomResourceDefinition{}, handler.EnqueueRequestsFromMapFunc(mapFunc), managedResourcePredicate).
+		Watches(&operatorv1alpha1.ExternalSecrets{}, handler.EnqueueRequestsFromMapFunc(mapFunc), builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		Complete(r)
+}
+
+// Reconcile is the reconciliation loop to manage the current state of managed CRDS
+// to match the desired state.
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	r.log.V(1).Info("reconciling", "request", req)
+
+	// Fetch the externalsecrets.openshift.operator.io CR
+	es := &operatorv1alpha1.ExternalSecrets{}
+	key := types.NamespacedName{
+		Name: common.ExternalSecretsObjectName,
+	}
+	if err := r.Get(ctx, key, es); err != nil {
+		if errors.IsNotFound(err) {
+			// NotFound errors, would mean the object hasn't been created yet and
+			// not required to reconcile yet.
+			r.log.V(1).Info("externalsecrets.openshift.operator.io object not found, skipping reconciliation", "key", key)
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("failed to fetch externalsecrets.openshift.operator.io %q during reconciliation: %w", key, err)
+	}
+
+	if common.IsInjectCertManagerAnnotationEnabled(es) {
+		return r.processReconcileRequest(es, req.NamespacedName)
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// processReconcileRequest is the reconciliation handler to manage the resources.
+func (r *Reconciler) processReconcileRequest(es *operatorv1alpha1.ExternalSecrets, req types.NamespacedName) (ctrl.Result, error) {
+	var oErr error = nil
+	if req.Name == reconcileObjectIdentifier {
+		if err := r.updateAnnotationsInAllCRDs(); err != nil {
+			oErr = fmt.Errorf("failed while updating annotations in all CRDs: %w", err)
+		}
+	} else {
+		crd := &crdv1.CustomResourceDefinition{}
+		if err := r.Get(r.ctx, req, crd); err != nil {
+			// NotFound error will be ignored since CRDs are managed by OLM, and OLM will
+			// reconcile it.
+			if errors.IsNotFound(err) {
+				r.log.V(1).Info("crd managed by OLM is not found, skipping reconciliation", "crd", req)
+				return ctrl.Result{}, nil
+			}
+			oErr = fmt.Errorf("failed to fetch customresourcedefinitions.apiextensions.k8s.io %q during reconciliation: %w", req, err)
+		}
+		if err := r.updateAnnotations(crd); err != nil {
+			oErr = fmt.Errorf("failed to update annotations in %q: %w", req, err)
+		}
+	}
+
+	if err := r.updateCondition(es, oErr); err != nil {
+		return ctrl.Result{}, utilerrors.NewAggregate([]error{err, oErr})
+	}
+
+	return ctrl.Result{}, oErr
+}
+
+// updateAnnotations is for updating the annotations on the managed CRDs.
+func (r *Reconciler) updateAnnotations(crd *crdv1.CustomResourceDefinition) error {
+	annotations := crd.GetAnnotations()
+	if val, ok := annotations[common.CertManagerInjectCAFromAnnotation]; !ok || val != common.CertManagerInjectCAFromAnnotationValue {
+		patch := client.RawPatch(types.MergePatchType,
+			[]byte(fmt.Sprintf("{\"metadata\":{\"annotations\":{\"%s\":\"%s\"}}}",
+				common.CertManagerInjectCAFromAnnotation, common.CertManagerInjectCAFromAnnotationValue)),
+		)
+		if err := r.Patch(r.ctx, crd, patch); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *Reconciler) updateAnnotationsInAllCRDs() error {
+	managedCRDList := &crdv1.CustomResourceDefinitionList{}
+	crdLabelFilter := map[string]string{
+		requestEnqueueLabelKey: requestEnqueueLabelValue,
+	}
+	if err := r.List(r.ctx, managedCRDList, client.MatchingLabels(crdLabelFilter)); err != nil {
+		return fmt.Errorf("failed to list managed CRD resources: %w", err)
+	}
+	if len(managedCRDList.Items) <= 0 {
+		r.log.Info("list query to fetch managed CRD resources returned empty")
+		return nil
+	}
+
+	for _, crd := range managedCRDList.Items {
+		if err := r.updateAnnotations(&crd); err != nil {
+			return fmt.Errorf("failed to update annotations in %q: %w", crd.GetName(), err)
+		}
+	}
+
+	return nil
+}
+
+func (r *Reconciler) updateCondition(es *operatorv1alpha1.ExternalSecrets, err error) error {
+	cond := metav1.Condition{
+		Type:               operatorv1alpha1.UpdateAnnotation,
+		ObservedGeneration: es.GetGeneration(),
+	}
+
+	if err != nil {
+		cond.Status = metav1.ConditionFalse
+		cond.Reason = operatorv1alpha1.ReasonFailed
+		cond.Message = fmt.Sprintf("failed to add annotations: %v", err.Error())
+	} else {
+		cond.Status = metav1.ConditionTrue
+		cond.Reason = operatorv1alpha1.ReasonCompleted
+		cond.Message = "successfully updated annotations"
+	}
+
+	if apimeta.SetStatusCondition(&es.Status.Conditions, cond) {
+		return r.updateStatus(r.ctx, es)
+	}
+
+	return nil
+}
+
+// updateStatus is for updating the status subresource of externalsecrets.openshift.operator.io.
+func (r *Reconciler) updateStatus(ctx context.Context, changed *operatorv1alpha1.ExternalSecrets) error {
+	namespacedName := types.NamespacedName{Name: changed.Name, Namespace: changed.Namespace}
+	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		r.log.V(4).Info("updating externalsecrets.openshift.operator.io status", "request", namespacedName)
+		current := &operatorv1alpha1.ExternalSecrets{}
+		if err := r.Get(ctx, namespacedName, current); err != nil {
+			return fmt.Errorf("failed to fetch externalsecrets.openshift.operator.io %q for status update: %w", namespacedName, err)
+		}
+		changed.Status.DeepCopyInto(&current.Status)
+
+		if err := r.StatusUpdate(ctx, current); err != nil {
+			return fmt.Errorf("failed to update externalsecrets.openshift.operator.io %q status: %w", namespacedName, err)
+		}
+
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/controller/crd_annotator/controller_test.go
+++ b/pkg/controller/crd_annotator/controller_test.go
@@ -1,0 +1,437 @@
+package crd_annotator
+
+import (
+	"context"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"testing"
+
+	crdv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/go-logr/logr/testr"
+
+	operatorv1alpha1 "github.com/openshift/external-secrets-operator/api/v1alpha1"
+	"github.com/openshift/external-secrets-operator/pkg/controller/client/fakes"
+	"github.com/openshift/external-secrets-operator/pkg/controller/common"
+	"github.com/openshift/external-secrets-operator/pkg/controller/commontest"
+)
+
+// testReconciler returns a sample Reconciler instance.
+func testReconciler(t *testing.T) *Reconciler {
+	return &Reconciler{
+		ctx: context.Background(),
+		log: testr.New(t),
+	}
+}
+
+// testExtendExternalSecrets enables CRD annotation specific configs on existing externalsecrets object.
+func testExtendExternalSecrets(es *operatorv1alpha1.ExternalSecrets) {
+	es.Spec = operatorv1alpha1.ExternalSecretsSpec{
+		ExternalSecretsConfig: &operatorv1alpha1.ExternalSecretsConfig{
+			WebhookConfig: &operatorv1alpha1.WebhookConfig{
+				CertManagerConfig: &operatorv1alpha1.CertManagerConfig{
+					AddInjectorAnnotations: "true",
+				},
+			},
+		},
+	}
+	return
+}
+
+// testCRD is for generating a sample CRD object for tests.
+func testCRD() *crdv1.CustomResourceDefinition {
+	return &crdv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: commontest.TestCRDName,
+			Annotations: map[string]string{
+				"testAnnotation": "true",
+			},
+		},
+		Spec: crdv1.CustomResourceDefinitionSpec{
+			Group: "operator.openshift.io",
+		},
+	}
+}
+
+func TestReconcile(t *testing.T) {
+	tests := []struct {
+		name                    string
+		request                 ctrl.Request
+		preReq                  func(*Reconciler, *fakes.FakeCtrlClient)
+		expectedStatusCondition []metav1.Condition
+		wantErr                 string
+	}{
+		{
+			name: "reconciliation successful for a specific CRD",
+			request: ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Name: commontest.TestCRDName,
+				},
+			},
+			preReq: func(r *Reconciler, m *fakes.FakeCtrlClient) {
+				m.GetCalls(func(ctx context.Context, ns types.NamespacedName, obj client.Object) error {
+					switch o := obj.(type) {
+					case *operatorv1alpha1.ExternalSecrets:
+						es := commontest.TestExternalSecrets()
+						testExtendExternalSecrets(es)
+						es.DeepCopyInto(o)
+					case *crdv1.CustomResourceDefinition:
+						crd := testCRD()
+						crd.DeepCopyInto(o)
+					}
+					return nil
+				})
+			},
+			expectedStatusCondition: []metav1.Condition{
+				{
+					Type:   operatorv1alpha1.UpdateAnnotation,
+					Status: metav1.ConditionTrue,
+					Reason: operatorv1alpha1.ReasonCompleted,
+				},
+			},
+		},
+		{
+			name: "reconciliation successful for all CRDs",
+			request: ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Name: reconcileObjectIdentifier,
+				},
+			},
+			preReq: func(r *Reconciler, m *fakes.FakeCtrlClient) {
+				m.GetCalls(func(ctx context.Context, ns types.NamespacedName, obj client.Object) error {
+					switch o := obj.(type) {
+					case *operatorv1alpha1.ExternalSecrets:
+						es := commontest.TestExternalSecrets()
+						testExtendExternalSecrets(es)
+						es.DeepCopyInto(o)
+					case *crdv1.CustomResourceDefinition:
+						crd := testCRD()
+						crd.DeepCopyInto(o)
+					}
+					return nil
+				})
+				m.ListCalls(func(ctx context.Context, obj client.ObjectList, opts ...client.ListOption) error {
+					switch o := obj.(type) {
+					case *crdv1.CustomResourceDefinitionList:
+						crdList := &crdv1.CustomResourceDefinitionList{}
+						crdList.Items = []crdv1.CustomResourceDefinition{
+							*testCRD(),
+						}
+						crdList.DeepCopyInto(o)
+					}
+					return nil
+				})
+			},
+			expectedStatusCondition: []metav1.Condition{
+				{
+					Type:   operatorv1alpha1.UpdateAnnotation,
+					Status: metav1.ConditionTrue,
+					Reason: operatorv1alpha1.ReasonCompleted,
+				},
+			},
+		},
+		{
+			name: "reconciliation fails when fetching externalsecrets",
+			request: ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Name: commontest.TestCRDName,
+				},
+			},
+			preReq: func(r *Reconciler, m *fakes.FakeCtrlClient) {
+				m.GetCalls(func(ctx context.Context, ns types.NamespacedName, obj client.Object) error {
+					switch o := obj.(type) {
+					case *operatorv1alpha1.ExternalSecrets:
+						return commontest.TestClientError
+					case *crdv1.CustomResourceDefinition:
+						crd := testCRD()
+						crd.DeepCopyInto(o)
+					}
+					return nil
+				})
+			},
+			expectedStatusCondition: []metav1.Condition{
+				{
+					Type:   operatorv1alpha1.UpdateAnnotation,
+					Status: metav1.ConditionFalse,
+					Reason: operatorv1alpha1.ReasonFailed,
+				},
+			},
+			wantErr: `failed to fetch externalsecrets.openshift.operator.io "/cluster" during reconciliation: test client error`,
+		},
+		{
+			name: "reconciliation successful externalsecrets does not exist",
+			request: ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Name: commontest.TestCRDName,
+				},
+			},
+			preReq: func(r *Reconciler, m *fakes.FakeCtrlClient) {
+				m.GetCalls(func(ctx context.Context, ns types.NamespacedName, obj client.Object) error {
+					switch o := obj.(type) {
+					case *operatorv1alpha1.ExternalSecrets:
+						return errors.NewNotFound(schema.GroupResource{
+							Group:    operatorv1alpha1.GroupVersion.Group,
+							Resource: "externalsecrets",
+						}, commontest.TestExternalSecretsResourceName)
+					case *crdv1.CustomResourceDefinition:
+						crd := testCRD()
+						crd.DeepCopyInto(o)
+					}
+					return nil
+				})
+			},
+			expectedStatusCondition: []metav1.Condition{},
+		},
+		{
+			name: "reconciliation successful config disabled",
+			request: ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Name: commontest.TestCRDName,
+				},
+			},
+			preReq: func(r *Reconciler, m *fakes.FakeCtrlClient) {
+				m.GetCalls(func(ctx context.Context, ns types.NamespacedName, obj client.Object) error {
+					switch o := obj.(type) {
+					case *operatorv1alpha1.ExternalSecrets:
+						es := commontest.TestExternalSecrets()
+						es.DeepCopyInto(o)
+					case *crdv1.CustomResourceDefinition:
+						crd := testCRD()
+						crd.DeepCopyInto(o)
+					}
+					return nil
+				})
+			},
+			expectedStatusCondition: []metav1.Condition{},
+		},
+		{
+			name: "reconciliation fails while listing CRD",
+			request: ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Name: reconcileObjectIdentifier,
+				},
+			},
+			preReq: func(r *Reconciler, m *fakes.FakeCtrlClient) {
+				m.GetCalls(func(ctx context.Context, ns types.NamespacedName, obj client.Object) error {
+					switch o := obj.(type) {
+					case *operatorv1alpha1.ExternalSecrets:
+						es := commontest.TestExternalSecrets()
+						testExtendExternalSecrets(es)
+						es.DeepCopyInto(o)
+					case *crdv1.CustomResourceDefinition:
+						return commontest.TestClientError
+					}
+					return nil
+				})
+				m.ListCalls(func(ctx context.Context, obj client.ObjectList, opts ...client.ListOption) error {
+					return commontest.TestClientError
+				})
+			},
+			expectedStatusCondition: []metav1.Condition{
+				{
+					Type:   operatorv1alpha1.UpdateAnnotation,
+					Status: metav1.ConditionFalse,
+					Reason: operatorv1alpha1.ReasonFailed,
+				},
+			},
+			wantErr: `failed while updating annotations in all CRDs: failed to list managed CRD resources: test client error`,
+		},
+		{
+			name: "reconciliation successful no required CRDs exist",
+			request: ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Name: reconcileObjectIdentifier,
+				},
+			},
+			preReq: func(r *Reconciler, m *fakes.FakeCtrlClient) {
+				m.GetCalls(func(ctx context.Context, ns types.NamespacedName, obj client.Object) error {
+					switch o := obj.(type) {
+					case *operatorv1alpha1.ExternalSecrets:
+						es := commontest.TestExternalSecrets()
+						testExtendExternalSecrets(es)
+						es.DeepCopyInto(o)
+					case *crdv1.CustomResourceDefinition:
+						return commontest.TestClientError
+					}
+					return nil
+				})
+				m.ListCalls(func(ctx context.Context, obj client.ObjectList, opts ...client.ListOption) error {
+					switch o := obj.(type) {
+					case *crdv1.CustomResourceDefinitionList:
+						crdList := &crdv1.CustomResourceDefinitionList{}
+						crdList.Items = []crdv1.CustomResourceDefinition{}
+						crdList.DeepCopyInto(o)
+					}
+					return nil
+				})
+			},
+			expectedStatusCondition: []metav1.Condition{
+				{
+					Type:   operatorv1alpha1.UpdateAnnotation,
+					Status: metav1.ConditionTrue,
+					Reason: operatorv1alpha1.ReasonCompleted,
+				},
+			},
+		},
+		{
+			name: "reconciliation fails while fetching CRD",
+			request: ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Name: commontest.TestCRDName,
+				},
+			},
+			preReq: func(r *Reconciler, m *fakes.FakeCtrlClient) {
+				m.GetCalls(func(ctx context.Context, ns types.NamespacedName, obj client.Object) error {
+					switch o := obj.(type) {
+					case *operatorv1alpha1.ExternalSecrets:
+						es := commontest.TestExternalSecrets()
+						testExtendExternalSecrets(es)
+						es.DeepCopyInto(o)
+					case *crdv1.CustomResourceDefinition:
+						return commontest.TestClientError
+					}
+					return nil
+				})
+			},
+			expectedStatusCondition: []metav1.Condition{
+				{
+					Type:   operatorv1alpha1.UpdateAnnotation,
+					Status: metav1.ConditionFalse,
+					Reason: operatorv1alpha1.ReasonFailed,
+				},
+			},
+			wantErr: `failed to fetch customresourcedefinitions.apiextensions.k8s.io "/test-crd" during reconciliation: test client error`,
+		},
+		{
+			name: "reconciliation successful while fetching non-existent CRD",
+			request: ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Name: commontest.TestCRDName,
+				},
+			},
+			preReq: func(r *Reconciler, m *fakes.FakeCtrlClient) {
+				m.GetCalls(func(ctx context.Context, ns types.NamespacedName, obj client.Object) error {
+					switch o := obj.(type) {
+					case *operatorv1alpha1.ExternalSecrets:
+						es := commontest.TestExternalSecrets()
+						testExtendExternalSecrets(es)
+						es.DeepCopyInto(o)
+					case *crdv1.CustomResourceDefinition:
+						return errors.NewNotFound(schema.GroupResource{
+							Group:    crdv1.SchemeGroupVersion.Group,
+							Resource: commontest.TestCRDName,
+						}, commontest.TestCRDName)
+					}
+					return nil
+				})
+			},
+			expectedStatusCondition: []metav1.Condition{
+				{
+					Type:   operatorv1alpha1.UpdateAnnotation,
+					Status: metav1.ConditionFalse,
+					Reason: operatorv1alpha1.ReasonFailed,
+				},
+			},
+		},
+		{
+			name: "reconciliation fails during annotation patch",
+			request: ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Name: commontest.TestCRDName,
+				},
+			},
+			preReq: func(r *Reconciler, m *fakes.FakeCtrlClient) {
+				m.GetCalls(func(ctx context.Context, ns types.NamespacedName, obj client.Object) error {
+					switch o := obj.(type) {
+					case *operatorv1alpha1.ExternalSecrets:
+						es := commontest.TestExternalSecrets()
+						testExtendExternalSecrets(es)
+						es.DeepCopyInto(o)
+					case *crdv1.CustomResourceDefinition:
+						crd := testCRD()
+						crd.DeepCopyInto(o)
+					}
+					return nil
+				})
+				m.PatchCalls(func(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+					return commontest.TestClientError
+				})
+			},
+			expectedStatusCondition: []metav1.Condition{
+				{
+					Type:   operatorv1alpha1.UpdateAnnotation,
+					Status: metav1.ConditionTrue,
+					Reason: operatorv1alpha1.ReasonCompleted,
+				},
+			},
+			wantErr: `failed to update annotations in "/test-crd": test client error`,
+		},
+		{
+			name: "reconciliation fails while updating status",
+			request: ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Name: commontest.TestCRDName,
+				},
+			},
+			preReq: func(r *Reconciler, m *fakes.FakeCtrlClient) {
+				m.GetCalls(func(ctx context.Context, ns types.NamespacedName, obj client.Object) error {
+					switch o := obj.(type) {
+					case *operatorv1alpha1.ExternalSecrets:
+						es := commontest.TestExternalSecrets()
+						testExtendExternalSecrets(es)
+						es.DeepCopyInto(o)
+					case *crdv1.CustomResourceDefinition:
+						crd := testCRD()
+						crd.DeepCopyInto(o)
+					}
+					return nil
+				})
+				m.StatusUpdateCalls(func(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+					return commontest.TestClientError
+				})
+			},
+			expectedStatusCondition: []metav1.Condition{
+				{
+					Type:   operatorv1alpha1.UpdateAnnotation,
+					Status: metav1.ConditionTrue,
+					Reason: operatorv1alpha1.ReasonCompleted,
+				},
+			},
+			wantErr: `failed to update externalsecrets.openshift.operator.io "/cluster" status: test client error`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := testReconciler(t)
+			mock := &fakes.FakeCtrlClient{}
+			if tt.preReq != nil {
+				tt.preReq(r, mock)
+			}
+			r.CtrlClient = mock
+			_, err := r.Reconcile(context.Background(), tt.request)
+
+			if (tt.wantErr != "" || err != nil) && (err == nil || err.Error() != tt.wantErr) {
+				t.Errorf("Reconcile() err: %v, wantErr: %v", err, tt.wantErr)
+			}
+			es := &operatorv1alpha1.ExternalSecrets{}
+			key := types.NamespacedName{
+				Name: common.ExternalSecretsObjectName,
+			}
+			r.CtrlClient.Get(r.ctx, key, es)
+			for _, c1 := range es.Status.Conditions {
+				for _, c2 := range tt.expectedStatusCondition {
+					if c1.Type == c2.Type {
+						if c1.Status != c2.Status || c1.Reason != c2.Reason {
+							t.Errorf("Reconcile() condition: %+v, expectedStatusCondition: %+v", c1, c2)
+						}
+					}
+				}
+			}
+		})
+	}
+}

--- a/pkg/controller/external_secrets/controller.go
+++ b/pkg/controller/external_secrets/controller.go
@@ -190,15 +190,15 @@ func BuildCustomClient(mgr ctrl.Manager, r *Reconciler) (client.Client, error) {
 	if _, ok := r.optionalResourcesList[certificateCRDGKV]; ok {
 		_, err = customCache.GetInformer(context.Background(), &certmanagerv1.Certificate{})
 		if err != nil {
-			return nil, fmt.Errorf("failed to add informer for %s resource: %w", certificateCRDGKV, err)
+			return nil, fmt.Errorf("failed to add informer for %s resource: %w", (&certmanagerv1.Certificate{}).GetObjectKind().GroupVersionKind().String(), err)
 		}
 		_, err = customCache.GetInformer(context.Background(), &certmanagerv1.ClusterIssuer{})
 		if err != nil {
-			return nil, fmt.Errorf("failed to add informer for %s resource: %w", certificateCRDGKV, err)
+			return nil, fmt.Errorf("failed to add informer for %s resource: %w", (&certmanagerv1.ClusterIssuer{}).GetObjectKind().GroupVersionKind().String(), err)
 		}
 		_, err = customCache.GetInformer(context.Background(), &certmanagerv1.Issuer{})
 		if err != nil {
-			return nil, fmt.Errorf("failed to add informer for %s resource: %w", certificateCRDGKV, err)
+			return nil, fmt.Errorf("failed to add informer for %s resource: %w", (&certmanagerv1.Issuer{}).GetObjectKind().GroupVersionKind().String(), err)
 		}
 	}
 	_, err = customCache.GetInformer(context.Background(), ownObject)

--- a/pkg/controller/external_secrets/deployments_test.go
+++ b/pkg/controller/external_secrets/deployments_test.go
@@ -205,7 +205,7 @@ func TestCreateOrApplyDeployments(t *testing.T) {
 					return nil
 				})
 			},
-			wantErr: `failed to update /externalsecrets-test-resource status with image info: failed to update externalsecrets.openshift.operator.io "/externalsecrets-test-resource" status: test client error`,
+			wantErr: `failed to update /cluster status with image info: failed to update externalsecrets.openshift.operator.io "/cluster" status: test client error`,
 		},
 		{
 			name: "deployment reconciliation with invalid toleration configuration",

--- a/pkg/controller/external_secrets/deployments_test.go
+++ b/pkg/controller/external_secrets/deployments_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/openshift/external-secrets-operator/api/v1alpha1"
 	"github.com/openshift/external-secrets-operator/pkg/controller/client/fakes"
+	"github.com/openshift/external-secrets-operator/pkg/controller/commontest"
 )
 
 func TestCreateOrApplyDeployments(t *testing.T) {
@@ -36,7 +37,7 @@ func TestCreateOrApplyDeployments(t *testing.T) {
 				})
 			},
 			updateExternalSecrets: func(i *v1alpha1.ExternalSecrets) {
-				i.Status.ExternalSecretsImage = testImageName
+				i.Status.ExternalSecretsImage = commontest.TestExternalSecretsImageName
 			},
 		},
 		{
@@ -60,7 +61,7 @@ func TestCreateOrApplyDeployments(t *testing.T) {
 				m.ExistsCalls(func(ctx context.Context, ns types.NamespacedName, obj client.Object) (bool, error) {
 					switch obj.(type) {
 					case *appsv1.Deployment:
-						return false, testError
+						return false, commontest.TestClientError
 					}
 					return true, nil
 				})
@@ -82,7 +83,7 @@ func TestCreateOrApplyDeployments(t *testing.T) {
 				m.UpdateWithRetryCalls(func(ctx context.Context, obj client.Object, _ ...client.UpdateOption) error {
 					switch obj.(type) {
 					case *appsv1.Deployment:
-						return testError
+						return commontest.TestClientError
 					}
 					return nil
 				})
@@ -199,7 +200,7 @@ func TestCreateOrApplyDeployments(t *testing.T) {
 				m.StatusUpdateCalls(func(ctx context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
 					switch obj.(type) {
 					case *v1alpha1.ExternalSecrets:
-						return testError
+						return commontest.TestClientError
 					}
 					return nil
 				})
@@ -361,13 +362,13 @@ func TestCreateOrApplyDeployments(t *testing.T) {
 				tt.preReq(r, mock)
 			}
 			r.CtrlClient = mock
-			externalsecrets := testExternalSecrets()
+			externalsecrets := commontest.TestExternalSecrets()
 			//externalsecrets.SetNamespace(testExternalSecretsNamespace)
 			if tt.updateExternalSecrets != nil {
 				tt.updateExternalSecrets(externalsecrets)
 			}
 			if !tt.skipEnvVar {
-				t.Setenv("RELATED_IMAGE_EXTERNAL_SECRETS", testImageName)
+				t.Setenv("RELATED_IMAGE_EXTERNAL_SECRETS", commontest.TestExternalSecretsImageName)
 			}
 			err := r.createOrApplyDeployments(externalsecrets, controllerDefaultResourceLabels, false)
 			if (tt.wantErr != "" || err != nil) && (err == nil || err.Error() != tt.wantErr) {
@@ -375,7 +376,7 @@ func TestCreateOrApplyDeployments(t *testing.T) {
 			}
 			if tt.wantErr == "" {
 				if tt.wantErr == "" {
-					if externalsecrets.Status.ExternalSecretsImage != testImageName {
+					if externalsecrets.Status.ExternalSecretsImage != commontest.TestExternalSecretsImageName {
 						t.Errorf("createOrApplyDeployments() got image in status: %v, want: %v", externalsecrets.Status.ExternalSecretsImage, "test-image")
 					}
 				}

--- a/pkg/controller/external_secrets/rbacs_test.go
+++ b/pkg/controller/external_secrets/rbacs_test.go
@@ -10,6 +10,7 @@ import (
 
 	operatorv1alpha1 "github.com/openshift/external-secrets-operator/api/v1alpha1"
 	"github.com/openshift/external-secrets-operator/pkg/controller/client/fakes"
+	"github.com/openshift/external-secrets-operator/pkg/controller/commontest"
 )
 
 func TestCreateOrApplyRBACResource(t *testing.T) {
@@ -25,7 +26,7 @@ func TestCreateOrApplyRBACResource(t *testing.T) {
 				m.ExistsCalls(func(ctx context.Context, ns types.NamespacedName, obj client.Object) (bool, error) {
 					switch obj.(type) {
 					case *rbacv1.ClusterRole:
-						return false, testError
+						return false, commontest.TestClientError
 					}
 					return true, nil
 				})
@@ -43,7 +44,7 @@ func TestCreateOrApplyRBACResource(t *testing.T) {
 				m.ExistsCalls(func(ctx context.Context, ns types.NamespacedName, obj client.Object) (bool, error) {
 					switch obj.(type) {
 					case *rbacv1.ClusterRoleBinding:
-						return false, testError
+						return false, commontest.TestClientError
 					}
 					return true, nil
 				})
@@ -56,7 +57,7 @@ func TestCreateOrApplyRBACResource(t *testing.T) {
 				m.ExistsCalls(func(ctx context.Context, ns types.NamespacedName, obj client.Object) (bool, error) {
 					switch obj.(type) {
 					case *rbacv1.Role:
-						return false, testError
+						return false, commontest.TestClientError
 					}
 					return true, nil
 				})
@@ -69,7 +70,7 @@ func TestCreateOrApplyRBACResource(t *testing.T) {
 				m.ExistsCalls(func(ctx context.Context, ns types.NamespacedName, obj client.Object) (bool, error) {
 					switch obj.(type) {
 					case *rbacv1.RoleBinding:
-						return false, testError
+						return false, commontest.TestClientError
 					}
 					return true, nil
 				})
@@ -91,7 +92,7 @@ func TestCreateOrApplyRBACResource(t *testing.T) {
 				m.UpdateWithRetryCalls(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
 					switch obj.(type) {
 					case *rbacv1.ClusterRoleBinding:
-						return testError
+						return commontest.TestClientError
 					}
 					return nil
 				})
@@ -126,7 +127,7 @@ func TestCreateOrApplyRBACResource(t *testing.T) {
 					switch obj.(type) {
 					case *rbacv1.ClusterRoleBinding:
 						if obj.GetName() == testClusterRoleBinding(certControllerClusterRoleBindingAssetName).GetName() {
-							return testError
+							return commontest.TestClientError
 						}
 					}
 					return nil
@@ -149,7 +150,7 @@ func TestCreateOrApplyRBACResource(t *testing.T) {
 				m.UpdateWithRetryCalls(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
 					switch obj.(type) {
 					case *rbacv1.ClusterRole:
-						return testError
+						return commontest.TestClientError
 					}
 					return nil
 				})
@@ -170,7 +171,7 @@ func TestCreateOrApplyRBACResource(t *testing.T) {
 					switch obj.(type) {
 					case *rbacv1.ClusterRole:
 						if obj.GetName() == testClusterRoleBinding(certControllerClusterRoleBindingAssetName).GetName() {
-							return testError
+							return commontest.TestClientError
 						}
 					}
 					return nil
@@ -193,7 +194,7 @@ func TestCreateOrApplyRBACResource(t *testing.T) {
 				m.UpdateWithRetryCalls(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
 					switch obj.(type) {
 					case *rbacv1.Role:
-						return testError
+						return commontest.TestClientError
 					}
 					return nil
 				})
@@ -213,7 +214,7 @@ func TestCreateOrApplyRBACResource(t *testing.T) {
 				m.CreateCalls(func(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
 					switch obj.(type) {
 					case *rbacv1.Role:
-						return testError
+						return commontest.TestClientError
 					}
 					return nil
 				})
@@ -235,7 +236,7 @@ func TestCreateOrApplyRBACResource(t *testing.T) {
 				m.UpdateWithRetryCalls(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
 					switch obj.(type) {
 					case *rbacv1.RoleBinding:
-						return testError
+						return commontest.TestClientError
 					}
 					return nil
 				})
@@ -255,7 +256,7 @@ func TestCreateOrApplyRBACResource(t *testing.T) {
 				m.CreateCalls(func(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
 					switch obj.(type) {
 					case *rbacv1.RoleBinding:
-						return testError
+						return commontest.TestClientError
 					}
 					return nil
 				})
@@ -304,7 +305,7 @@ func TestCreateOrApplyRBACResource(t *testing.T) {
 			}
 			r.CtrlClient = mock
 
-			es := testExternalSecrets()
+			es := commontest.TestExternalSecrets()
 			if tt.updateExternalSecretsObj != nil {
 				tt.updateExternalSecretsObj(es)
 			}

--- a/pkg/controller/external_secrets/secret_test.go
+++ b/pkg/controller/external_secrets/secret_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/openshift/external-secrets-operator/api/v1alpha1"
 	"github.com/openshift/external-secrets-operator/pkg/controller/client/fakes"
+	"github.com/openshift/external-secrets-operator/pkg/controller/commontest"
 )
 
 const (
@@ -73,7 +74,7 @@ func TestCreateOrApplySecret(t *testing.T) {
 				m.GetCalls(func(ctx context.Context, ns types.NamespacedName, obj client.Object) error {
 					switch o := obj.(type) {
 					case *corev1.Secret:
-						secret := testSecret()
+						secret := testSecret(webhookTLSSecretAssetName)
 						secret.DeepCopyInto(o)
 					}
 					return nil
@@ -81,12 +82,12 @@ func TestCreateOrApplySecret(t *testing.T) {
 				m.ExistsCalls(func(ctx context.Context, ns types.NamespacedName, obj client.Object) (bool, error) {
 					switch obj.(type) {
 					case *corev1.Secret:
-						return false, testError
+						return false, commontest.TestClientError
 					}
 					return true, nil
 				})
 			},
-			wantErr: fmt.Sprintf("failed to check %s/%s secret resource already exists: %s", testNamespace, testValidateSecretResourceName, testError),
+			wantErr: fmt.Sprintf("failed to check %s/%s secret resource already exists: %s", commontest.TestExternalSecretsNamespace, testValidateSecretResourceName, commontest.TestClientError),
 		},
 		{
 			name: "reconciliation of secret fails while restoring to expected state",
@@ -94,7 +95,7 @@ func TestCreateOrApplySecret(t *testing.T) {
 				m.GetCalls(func(ctx context.Context, ns types.NamespacedName, obj client.Object) error {
 					switch o := obj.(type) {
 					case *corev1.Secret:
-						secret := testSecret()
+						secret := testSecret(webhookTLSSecretAssetName)
 						secret.DeepCopyInto(o)
 					}
 					return nil
@@ -102,7 +103,7 @@ func TestCreateOrApplySecret(t *testing.T) {
 				m.ExistsCalls(func(ctx context.Context, ns types.NamespacedName, obj client.Object) (bool, error) {
 					switch o := obj.(type) {
 					case *corev1.Secret:
-						secret := testSecret()
+						secret := testSecret(webhookTLSSecretAssetName)
 						secret.SetLabels(map[string]string{"test": "test"})
 						secret.DeepCopyInto(o)
 					}
@@ -111,12 +112,12 @@ func TestCreateOrApplySecret(t *testing.T) {
 				m.UpdateWithRetryCalls(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
 					switch obj.(type) {
 					case *corev1.Secret:
-						return testError
+						return commontest.TestClientError
 					}
 					return nil
 				})
 			},
-			wantErr: fmt.Sprintf("failed to update %s/%s secret resource: %s", testNamespace, testValidateSecretResourceName, testError),
+			wantErr: fmt.Sprintf("failed to update %s/%s secret resource: %s", commontest.TestExternalSecretsNamespace, testValidateSecretResourceName, commontest.TestClientError),
 		},
 		{
 			name: "reconciliation of secret which already exists in expected state",
@@ -124,7 +125,7 @@ func TestCreateOrApplySecret(t *testing.T) {
 				m.GetCalls(func(ctx context.Context, ns types.NamespacedName, obj client.Object) error {
 					switch o := obj.(type) {
 					case *corev1.Secret:
-						secret := testSecret()
+						secret := testSecret(webhookTLSSecretAssetName)
 						secret.DeepCopyInto(o)
 					}
 					return nil
@@ -132,7 +133,7 @@ func TestCreateOrApplySecret(t *testing.T) {
 				m.ExistsCalls(func(ctx context.Context, ns types.NamespacedName, obj client.Object) (bool, error) {
 					switch o := obj.(type) {
 					case *corev1.Secret:
-						secret := testSecret()
+						secret := testSecret(webhookTLSSecretAssetName)
 						secret.DeepCopyInto(o)
 					}
 					return true, nil
@@ -145,7 +146,7 @@ func TestCreateOrApplySecret(t *testing.T) {
 				m.GetCalls(func(ctx context.Context, ns types.NamespacedName, obj client.Object) error {
 					switch o := obj.(type) {
 					case *corev1.Secret:
-						secret := testSecret()
+						secret := testSecret(webhookTLSSecretAssetName)
 						secret.DeepCopyInto(o)
 					}
 					return nil
@@ -160,12 +161,12 @@ func TestCreateOrApplySecret(t *testing.T) {
 				m.CreateCalls(func(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
 					switch obj.(type) {
 					case *corev1.Secret:
-						return testError
+						return commontest.TestClientError
 					}
 					return nil
 				})
 			},
-			wantErr: fmt.Sprintf("failed to create %s/%s secret resource: %s", testNamespace, testValidateSecretResourceName, testError),
+			wantErr: fmt.Sprintf("failed to create %s/%s secret resource: %s", commontest.TestExternalSecretsNamespace, testValidateSecretResourceName, commontest.TestClientError),
 		},
 		{
 			name: "successful secret creation",
@@ -208,11 +209,11 @@ func TestCreateOrApplySecret(t *testing.T) {
 }
 
 func testExternalSecretsForSecrets() *v1alpha1.ExternalSecrets {
-	externalSecrets := testExternalSecrets()
+	externalSecrets := commontest.TestExternalSecrets()
 
 	externalSecrets.Spec = v1alpha1.ExternalSecretsSpec{
 		ControllerConfig: &v1alpha1.ControllerConfig{
-			Namespace: testNamespace,
+			Namespace: commontest.TestExternalSecretsNamespace,
 		},
 		ExternalSecretsConfig: &v1alpha1.ExternalSecretsConfig{
 			WebhookConfig: &v1alpha1.WebhookConfig{

--- a/pkg/controller/external_secrets/service_test.go
+++ b/pkg/controller/external_secrets/service_test.go
@@ -10,6 +10,7 @@ import (
 
 	operatorv1alpha1 "github.com/openshift/external-secrets-operator/api/v1alpha1"
 	"github.com/openshift/external-secrets-operator/pkg/controller/client/fakes"
+	"github.com/openshift/external-secrets-operator/pkg/controller/commontest"
 )
 
 func TestCreateOrApplyServices(t *testing.T) {
@@ -49,7 +50,7 @@ func TestCreateOrApplyServices(t *testing.T) {
 					switch svc := obj.(type) {
 					case *corev1.Service:
 						if svc.Name == "bitwarden-sdk-server" {
-							return testError // trigger error
+							return commontest.TestClientError // trigger error
 						}
 					}
 					return nil
@@ -69,7 +70,7 @@ func TestCreateOrApplyServices(t *testing.T) {
 			name: "service reconciliation fails while checking if exists",
 			preReq: func(r *Reconciler, m *fakes.FakeCtrlClient) {
 				m.ExistsCalls(func(ctx context.Context, ns types.NamespacedName, obj client.Object) (bool, error) {
-					return false, testError
+					return false, commontest.TestClientError
 				})
 			},
 			wantErr: `failed to check existence of service external-secrets/external-secrets-webhook: test client error`,
@@ -88,7 +89,7 @@ func TestCreateOrApplyServices(t *testing.T) {
 					return false, nil
 				})
 				m.UpdateWithRetryCalls(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
-					return testError
+					return commontest.TestClientError
 				})
 			},
 			wantErr: `failed to update service external-secrets/external-secrets-webhook: test client error`,
@@ -106,7 +107,7 @@ func TestCreateOrApplyServices(t *testing.T) {
 							t.Errorf("Expected webhook service to be created, got %s", svc.Name)
 						}
 					}
-					return testError
+					return commontest.TestClientError
 				})
 			},
 			wantErr: `failed to create service external-secrets/external-secrets-webhook: test client error`,
@@ -121,7 +122,7 @@ func TestCreateOrApplyServices(t *testing.T) {
 				tt.preReq(r, mock)
 			}
 			r.CtrlClient = mock
-			es := testExternalSecrets()
+			es := commontest.TestExternalSecrets()
 			if tt.updateExternalSecretsObj != nil {
 				tt.updateExternalSecretsObj(es)
 			}

--- a/pkg/controller/external_secrets/serviceaccounts_test.go
+++ b/pkg/controller/external_secrets/serviceaccounts_test.go
@@ -11,6 +11,7 @@ import (
 
 	operatorv1alpha1 "github.com/openshift/external-secrets-operator/api/v1alpha1"
 	"github.com/openshift/external-secrets-operator/pkg/controller/client/fakes"
+	"github.com/openshift/external-secrets-operator/pkg/controller/commontest"
 )
 
 var testErr = fmt.Errorf("test client error")
@@ -128,7 +129,7 @@ func TestCreateOrApplyServiceAccounts(t *testing.T) {
 				tt.preReq(r, mock)
 			}
 
-			es := testExternalSecrets()
+			es := commontest.TestExternalSecrets()
 			if tt.updateExternalSecretsObj != nil {
 				tt.updateExternalSecretsObj(es)
 			}

--- a/pkg/controller/external_secrets/test_utils.go
+++ b/pkg/controller/external_secrets/test_utils.go
@@ -2,7 +2,6 @@ package external_secrets
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	webhook "k8s.io/api/admissionregistration/v1"
@@ -17,23 +16,9 @@ import (
 
 	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 
-	operatorv1alpha1 "github.com/openshift/external-secrets-operator/api/v1alpha1"
 	"github.com/openshift/external-secrets-operator/pkg/controller/common"
+	"github.com/openshift/external-secrets-operator/pkg/controller/commontest"
 	"github.com/openshift/external-secrets-operator/pkg/operator/assets"
-)
-
-const (
-	// testResourcesName is the name for ExternalSecrets test CR.
-	testResourcesName = "externalsecrets-test-resource"
-
-	testImageName = "registry.redhat.io/external-secrets-operator/external-secrets-operator-rhel9"
-
-	testNamespace = "test-external-secrets"
-)
-
-var (
-	// testError is the error to return for client failure scenarios.
-	testError = fmt.Errorf("test client error")
 )
 
 // testReconciler returns a sample Reconciler instance.
@@ -43,7 +28,7 @@ func testReconciler(t *testing.T) *Reconciler {
 		ctx:                   context.Background(),
 		eventRecorder:         record.NewFakeRecorder(100),
 		log:                   testr.New(t),
-		esm:                   testExternalSecretsManager(),
+		esm:                   commontest.TestExternalSecretsManager(),
 		optionalResourcesList: make(map[string]struct{}),
 	}
 }
@@ -60,24 +45,6 @@ func testServiceAccount(assetName string) *corev1.ServiceAccount {
 	serviceAccount := common.DecodeServiceAccountObjBytes(assets.MustAsset(assetName))
 	serviceAccount.SetLabels(controllerDefaultResourceLabels)
 	return serviceAccount
-}
-
-// testExternalSecrets returns a sample ExternalSecrets object.
-func testExternalSecrets() *operatorv1alpha1.ExternalSecrets {
-	return &operatorv1alpha1.ExternalSecrets{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: testResourcesName,
-		},
-	}
-}
-
-// testExternalSecretsManager returns a sample ExternalSecretsManager object.
-func testExternalSecretsManager() *operatorv1alpha1.ExternalSecretsManager {
-	return &operatorv1alpha1.ExternalSecretsManager{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: testResourcesName,
-		},
-	}
 }
 
 // testClusterRole returns ClusterRole object read from provided static asset of same kind.
@@ -108,8 +75,9 @@ func testRoleBinding(assetName string) *rbacv1.RoleBinding {
 	return roleBinding
 }
 
-func testValidatingWebhookConfiguration(testValidateWebhookConfigurationFile string) *webhook.ValidatingWebhookConfiguration {
-	validateWebhook := common.DecodeValidatingWebhookConfigurationObjBytes(assets.MustAsset(testValidateWebhookConfigurationFile))
+// testValidatingWebhookConfiguration returns ValidatingWebhookConfiguration object read from provided static asset of same kind.
+func testValidatingWebhookConfiguration(assetName string) *webhook.ValidatingWebhookConfiguration {
+	validateWebhook := common.DecodeValidatingWebhookConfigurationObjBytes(assets.MustAsset(assetName))
 	return validateWebhook
 }
 
@@ -129,7 +97,7 @@ func testDeployment(name string) *appsv1.Deployment {
 					Containers: []corev1.Container{
 						{
 							Name:  externalsecretsCommonName,
-							Image: testImageName,
+							Image: commontest.TestExternalSecretsImageName,
 						},
 					},
 				},
@@ -138,14 +106,16 @@ func testDeployment(name string) *appsv1.Deployment {
 	}
 }
 
-func testCertificate() *v1.Certificate {
-	validateCertificate := common.DecodeCertificateObjBytes(assets.MustAsset(webhookCertificateAssetName))
+// testCertificate returns Certificate object read from provided static asset of same kind.
+func testCertificate(assetName string) *v1.Certificate {
+	validateCertificate := common.DecodeCertificateObjBytes(assets.MustAsset(assetName))
 	validateCertificate.SetLabels(controllerDefaultResourceLabels)
 	return validateCertificate
 }
 
-func testSecret() *corev1.Secret {
-	validateSecret := common.DecodeSecretObjBytes(assets.MustAsset(webhookTLSSecretAssetName))
+// testSecret returns Secret object read from provided static asset of same kind.
+func testSecret(assetName string) *corev1.Secret {
+	validateSecret := common.DecodeSecretObjBytes(assets.MustAsset(assetName))
 	validateSecret.SetLabels(controllerDefaultResourceLabels)
 	return validateSecret
 }

--- a/pkg/controller/external_secrets/utils.go
+++ b/pkg/controller/external_secrets/utils.go
@@ -159,3 +159,8 @@ func getOperatingNamespace(externalsecrets *operatorv1alpha1.ExternalSecrets) st
 	}
 	return externalsecrets.Spec.ExternalSecretsConfig.OperatingNamespace
 }
+
+func (r *Reconciler) IsCertManagerInstalled() bool {
+	_, ok := r.optionalResourcesList[certificateCRDGKV]
+	return ok
+}

--- a/pkg/controller/external_secrets/validatingwebhook_test.go
+++ b/pkg/controller/external_secrets/validatingwebhook_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/openshift/external-secrets-operator/api/v1alpha1"
 	"github.com/openshift/external-secrets-operator/pkg/controller/client/fakes"
+	"github.com/openshift/external-secrets-operator/pkg/controller/commontest"
 )
 
 var (
@@ -42,12 +43,12 @@ func TestCreateOrApplyValidatingWebhookConfiguration(t *testing.T) {
 				m.ExistsCalls(func(ctx context.Context, ns types.NamespacedName, obj client.Object) (bool, error) {
 					switch obj.(type) {
 					case *webhook.ValidatingWebhookConfiguration:
-						return false, testError
+						return false, commontest.TestClientError
 					}
 					return false, nil
 				})
 			},
-			wantErr: fmt.Sprintf("failed to check %s validatingWebhook resource already exists: %s", testValidateWebhookConfigurationResourceName, testError),
+			wantErr: fmt.Sprintf("failed to check %s validatingWebhook resource already exists: %s", testValidateWebhookConfigurationResourceName, commontest.TestClientError),
 		},
 		{
 			name: "validatingWebhookConfiguration reconciliation fails while updating to desired state",
@@ -55,7 +56,7 @@ func TestCreateOrApplyValidatingWebhookConfiguration(t *testing.T) {
 				m.UpdateWithRetryCalls(func(ctx context.Context, obj client.Object, option ...client.UpdateOption) error {
 					switch obj.(type) {
 					case *webhook.ValidatingWebhookConfiguration:
-						return testError
+						return commontest.TestClientError
 					}
 					return nil
 				})
@@ -70,7 +71,7 @@ func TestCreateOrApplyValidatingWebhookConfiguration(t *testing.T) {
 					return false, nil
 				})
 			},
-			wantErr: fmt.Sprintf("failed to update %s validatingWebhook resource with desired state: %s", testValidateWebhookConfigurationResourceName, testError),
+			wantErr: fmt.Sprintf("failed to update %s validatingWebhook resource with desired state: %s", testValidateWebhookConfigurationResourceName, commontest.TestClientError),
 		},
 		{
 			name: "validatingWebhookConfiguration reconciliation fails while creating",
@@ -78,12 +79,12 @@ func TestCreateOrApplyValidatingWebhookConfiguration(t *testing.T) {
 				m.CreateCalls(func(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
 					switch obj.(type) {
 					case *webhook.ValidatingWebhookConfiguration:
-						return testError
+						return commontest.TestClientError
 					}
 					return nil
 				})
 			},
-			wantErr: fmt.Sprintf("failed to create validatingWebhook resource %s: %s", testValidateWebhookConfigurationResourceName, testError),
+			wantErr: fmt.Sprintf("failed to create validatingWebhook resource %s: %s", testValidateWebhookConfigurationResourceName, commontest.TestClientError),
 		},
 		{
 			name: "validatingWebhookConfiguration creation successful",
@@ -116,7 +117,7 @@ func TestCreateOrApplyValidatingWebhookConfiguration(t *testing.T) {
 }
 
 func testExternalSecretsForValidateWebhookConfiguration() *v1alpha1.ExternalSecrets {
-	externalSecrets := testExternalSecrets()
+	externalSecrets := commontest.TestExternalSecrets()
 	externalSecrets.Spec = v1alpha1.ExternalSecretsSpec{
 		ExternalSecretsConfig: &v1alpha1.ExternalSecretsConfig{
 			WebhookConfig: &v1alpha1.WebhookConfig{

--- a/pkg/operator/setup_manager.go
+++ b/pkg/operator/setup_manager.go
@@ -3,6 +3,7 @@ package operator
 import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
+	crdannotator "github.com/openshift/external-secrets-operator/pkg/controller/crd_annotator"
 	externalsecretscontroller "github.com/openshift/external-secrets-operator/pkg/controller/external_secrets"
 )
 
@@ -18,6 +19,19 @@ func StartControllers(mgr ctrl.Manager) error {
 		logger.Error(err, "failed to set up controller with manager",
 			"controller", externalsecretscontroller.ControllerName)
 		return err
+	}
+
+	if externalsecrets.IsCertManagerInstalled() {
+		crdAnnotator, err := crdannotator.New(mgr)
+		if err != nil {
+			logger.Error(err, "failed to create crd annotator controller", "controller", externalsecretscontroller.ControllerName)
+			return err
+		}
+		if err = crdAnnotator.SetupWithManager(mgr); err != nil {
+			logger.Error(err, "failed to set up crd_annotator controller with manager",
+				"controller", crdannotator.ControllerName)
+			return err
+		}
 	}
 
 	return nil

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -25,6 +25,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	crdv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientscheme "k8s.io/client-go/kubernetes/scheme"
@@ -46,6 +47,7 @@ func init() {
 	utilruntime.Must(corev1.AddToScheme(scheme))
 	utilruntime.Must(rbacv1.AddToScheme(scheme))
 	utilruntime.Must(certmanagerv1.AddToScheme(scheme))
+	utilruntime.Must(crdv1.AddToScheme(scheme))
 	utilruntime.Must(operatorv1alpha1.AddToScheme(scheme))
 }
 


### PR DESCRIPTION
PR has following changes:
- Refactor's unit test code to avoid code duplication.
- Adds new controller to manage annotations on external-secrets operand CRD.
- Updates `externalsecrets.operator.openshift.io` CR status with annotation update condition.