### PR TITLE
ESO-83: Adds provision for setting operator loglevel using env var

### DIFF
--- a/bundle/manifests/external-secrets-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/external-secrets-operator.clusterserviceversion.yaml
@@ -33,7 +33,7 @@ metadata:
     categories: Security
     console.openshift.io/disable-operand-delete: "true"
     containerImage: ""
-    createdAt: "2025-06-17T11:54:07Z"
+    createdAt: "2025-06-20T09:36:52Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -421,7 +421,7 @@ spec:
               containers:
               - args:
                 - --metrics-bind-address=:8443
-                - --v=2
+                - --v=$(OPERATOR_LOG_LEVEL)
                 - --leader-elect
                 - --health-probe-bind-address=:8081
                 command:
@@ -435,6 +435,8 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.name
+                - name: OPERATOR_LOG_LEVEL
+                  value: "2"
                 - name: OPERATOR_NAME
                   value: external-secrets-operator
                 - name: OPERATOR_IMAGE_VERSION

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -52,7 +52,7 @@ spec:
       - command:
         - /bin/external-secrets-operator
         args:
-          - --v=2
+          - --v=$(OPERATOR_LOG_LEVEL)
           - --leader-elect
           - --health-probe-bind-address=:8081
         env:
@@ -64,6 +64,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
+          - name: OPERATOR_LOG_LEVEL
+            value: "2"
           - name: OPERATOR_NAME
             value: external-secrets-operator
           - name: OPERATOR_IMAGE_VERSION


### PR DESCRIPTION
The PR is for adding the provision for user to modify the operator loglevel by setting `OPERATOR_LOG_LEVEL` env var in the operator's subscription object.