### PR TITLE
ESO-2: Updates external-secrets CRDs to v0.14.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 VERSION ?= 0.1.0
 
 # EXTERNAL_SECRETS_VERSION defines the external-secrets release version to fetch helm charts.
-EXTERNAL_SECRETS_VERSION ?= v0.14.0
+EXTERNAL_SECRETS_VERSION ?= v0.14.3
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/bindata/external-secrets/resources/certificate_external-secrets-webhook.yml
+++ b/bindata/external-secrets/resources/certificate_external-secrets-webhook.yml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets-webhook
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v0.14.0"
+    app.kubernetes.io/version: "v0.14.3"
     app.kubernetes.io/managed-by: external-secrets-operator
     external-secrets.io/component: webhook
 spec:

--- a/bindata/external-secrets/resources/clusterrole_external-secrets-cert-controller.yml
+++ b/bindata/external-secrets/resources/clusterrole_external-secrets-cert-controller.yml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets-cert-controller
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v0.14.0"
+    app.kubernetes.io/version: "v0.14.3"
     app.kubernetes.io/managed-by: external-secrets-operator
 rules:
   - apiGroups:

--- a/bindata/external-secrets/resources/clusterrole_external-secrets-controller.yml
+++ b/bindata/external-secrets/resources/clusterrole_external-secrets-controller.yml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v0.14.0"
+    app.kubernetes.io/version: "v0.14.3"
     app.kubernetes.io/managed-by: external-secrets-operator
 rules:
   - apiGroups:

--- a/bindata/external-secrets/resources/clusterrole_external-secrets-edit.yml
+++ b/bindata/external-secrets/resources/clusterrole_external-secrets-edit.yml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v0.14.0"
+    app.kubernetes.io/version: "v0.14.3"
     app.kubernetes.io/managed-by: external-secrets-operator
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"

--- a/bindata/external-secrets/resources/clusterrole_external-secrets-servicebindings.yml
+++ b/bindata/external-secrets/resources/clusterrole_external-secrets-servicebindings.yml
@@ -7,7 +7,7 @@ metadata:
     servicebinding.io/controller: "true"
     app.kubernetes.io/name: external-secrets
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v0.14.0"
+    app.kubernetes.io/version: "v0.14.3"
     app.kubernetes.io/managed-by: external-secrets-operator
 rules:
   - apiGroups:

--- a/bindata/external-secrets/resources/clusterrole_external-secrets-view.yml
+++ b/bindata/external-secrets/resources/clusterrole_external-secrets-view.yml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v0.14.0"
+    app.kubernetes.io/version: "v0.14.3"
     app.kubernetes.io/managed-by: external-secrets-operator
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"

--- a/bindata/external-secrets/resources/clusterrolebinding_external-secrets-cert-controller.yml
+++ b/bindata/external-secrets/resources/clusterrolebinding_external-secrets-cert-controller.yml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets-cert-controller
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v0.14.0"
+    app.kubernetes.io/version: "v0.14.3"
     app.kubernetes.io/managed-by: external-secrets-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/bindata/external-secrets/resources/clusterrolebinding_external-secrets-controller.yml
+++ b/bindata/external-secrets/resources/clusterrolebinding_external-secrets-controller.yml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v0.14.0"
+    app.kubernetes.io/version: "v0.14.3"
     app.kubernetes.io/managed-by: external-secrets-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/bindata/external-secrets/resources/deployment_external-secrets-cert-controller.yml
+++ b/bindata/external-secrets/resources/deployment_external-secrets-cert-controller.yml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets-cert-controller
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v0.14.0"
+    app.kubernetes.io/version: "v0.14.3"
     app.kubernetes.io/managed-by: external-secrets-operator
 spec:
   replicas: 1
@@ -21,7 +21,7 @@ spec:
       labels:
         app.kubernetes.io/name: external-secrets-cert-controller
         app.kubernetes.io/instance: external-secrets
-        app.kubernetes.io/version: "v0.14.0"
+        app.kubernetes.io/version: "v0.14.3"
         app.kubernetes.io/managed-by: external-secrets-operator
     spec:
       serviceAccountName: external-secrets-cert-controller
@@ -39,7 +39,7 @@ spec:
             runAsUser: 1000
             seccompProfile:
               type: RuntimeDefault
-          image: oci.external-secrets.io/external-secrets/external-secrets:v0.14.0
+          image: oci.external-secrets.io/external-secrets/external-secrets:v0.14.3
           imagePullPolicy: IfNotPresent
           args:
             - certcontroller

--- a/bindata/external-secrets/resources/deployment_external-secrets-webhook.yml
+++ b/bindata/external-secrets/resources/deployment_external-secrets-webhook.yml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets-webhook
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v0.14.0"
+    app.kubernetes.io/version: "v0.14.3"
     app.kubernetes.io/managed-by: external-secrets-operator
 spec:
   replicas: 1
@@ -21,7 +21,7 @@ spec:
       labels:
         app.kubernetes.io/name: external-secrets-webhook
         app.kubernetes.io/instance: external-secrets
-        app.kubernetes.io/version: "v0.14.0"
+        app.kubernetes.io/version: "v0.14.3"
         app.kubernetes.io/managed-by: external-secrets-operator
     spec:
       hostNetwork: false
@@ -39,7 +39,7 @@ spec:
             runAsUser: 1000
             seccompProfile:
               type: RuntimeDefault
-          image: oci.external-secrets.io/external-secrets/external-secrets:v0.14.0
+          image: oci.external-secrets.io/external-secrets/external-secrets:v0.14.3
           imagePullPolicy: IfNotPresent
           args:
             - webhook

--- a/bindata/external-secrets/resources/deployment_external-secrets.yml
+++ b/bindata/external-secrets/resources/deployment_external-secrets.yml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v0.14.0"
+    app.kubernetes.io/version: "v0.14.3"
     app.kubernetes.io/managed-by: external-secrets-operator
 spec:
   replicas: 1
@@ -21,7 +21,7 @@ spec:
       labels:
         app.kubernetes.io/name: external-secrets
         app.kubernetes.io/instance: external-secrets
-        app.kubernetes.io/version: "v0.14.0"
+        app.kubernetes.io/version: "v0.14.3"
         app.kubernetes.io/managed-by: external-secrets-operator
     spec:
       serviceAccountName: external-secrets
@@ -39,7 +39,7 @@ spec:
             runAsUser: 1000
             seccompProfile:
               type: RuntimeDefault
-          image: oci.external-secrets.io/external-secrets/external-secrets:v0.14.0
+          image: oci.external-secrets.io/external-secrets/external-secrets:v0.14.3
           imagePullPolicy: IfNotPresent
           args:
             - --concurrent=1

--- a/bindata/external-secrets/resources/role_external-secrets-leaderelection.yml
+++ b/bindata/external-secrets/resources/role_external-secrets-leaderelection.yml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v0.14.0"
+    app.kubernetes.io/version: "v0.14.3"
     app.kubernetes.io/managed-by: external-secrets-operator
 rules:
   - apiGroups:

--- a/bindata/external-secrets/resources/rolebinding_external-secrets-leaderelection.yml
+++ b/bindata/external-secrets/resources/rolebinding_external-secrets-leaderelection.yml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v0.14.0"
+    app.kubernetes.io/version: "v0.14.3"
     app.kubernetes.io/managed-by: external-secrets-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/bindata/external-secrets/resources/secret_external-secrets-webhook.yml
+++ b/bindata/external-secrets/resources/secret_external-secrets-webhook.yml
@@ -7,6 +7,6 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets-webhook
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v0.14.0"
+    app.kubernetes.io/version: "v0.14.3"
     app.kubernetes.io/managed-by: external-secrets-operator
     external-secrets.io/component: webhook

--- a/bindata/external-secrets/resources/service_external-secrets-webhook.yml
+++ b/bindata/external-secrets/resources/service_external-secrets-webhook.yml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets-webhook
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v0.14.0"
+    app.kubernetes.io/version: "v0.14.3"
     app.kubernetes.io/managed-by: external-secrets-operator
     external-secrets.io/component: webhook
 spec:

--- a/bindata/external-secrets/resources/serviceaccount_external-secrets-cert-controller.yml
+++ b/bindata/external-secrets/resources/serviceaccount_external-secrets-cert-controller.yml
@@ -7,5 +7,5 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets-cert-controller
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v0.14.0"
+    app.kubernetes.io/version: "v0.14.3"
     app.kubernetes.io/managed-by: external-secrets-operator

--- a/bindata/external-secrets/resources/serviceaccount_external-secrets-webhook.yml
+++ b/bindata/external-secrets/resources/serviceaccount_external-secrets-webhook.yml
@@ -7,5 +7,5 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets-webhook
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v0.14.0"
+    app.kubernetes.io/version: "v0.14.3"
     app.kubernetes.io/managed-by: external-secrets-operator

--- a/bindata/external-secrets/resources/serviceaccount_external-secrets.yml
+++ b/bindata/external-secrets/resources/serviceaccount_external-secrets.yml
@@ -7,5 +7,5 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v0.14.0"
+    app.kubernetes.io/version: "v0.14.3"
     app.kubernetes.io/managed-by: external-secrets-operator

--- a/bindata/external-secrets/resources/validatingwebhookconfiguration_externalsecret-validate.yml
+++ b/bindata/external-secrets/resources/validatingwebhookconfiguration_externalsecret-validate.yml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets-webhook
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v0.14.0"
+    app.kubernetes.io/version: "v0.14.3"
     app.kubernetes.io/managed-by: external-secrets-operator
     external-secrets.io/component: webhook
 webhooks:

--- a/bindata/external-secrets/resources/validatingwebhookconfiguration_secretstore-validate.yml
+++ b/bindata/external-secrets/resources/validatingwebhookconfiguration_secretstore-validate.yml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets-webhook
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v0.14.0"
+    app.kubernetes.io/version: "v0.14.3"
     app.kubernetes.io/managed-by: external-secrets-operator
     external-secrets.io/component: webhook
 webhooks:

--- a/bundle/manifests/external-secrets-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/external-secrets-operator.clusterserviceversion.yaml
@@ -205,7 +205,7 @@ metadata:
     categories: Security
     console.openshift.io/disable-operand-delete: "true"
     containerImage: ""
-    createdAt: "2025-06-20T09:36:52Z"
+    createdAt: "2025-06-24T04:29:21Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"

--- a/bundle/manifests/external-secrets.io_clusterexternalsecrets.yaml
+++ b/bundle/manifests/external-secrets.io_clusterexternalsecrets.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   creationTimestamp: null
   labels:
     app: external-secrets

--- a/bundle/manifests/external-secrets.io_clustersecretstores.yaml
+++ b/bundle/manifests/external-secrets.io_clustersecretstores.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   creationTimestamp: null
   labels:
     app: external-secrets
@@ -3765,6 +3765,83 @@ spec:
                         description: ProjectID project where secret is located
                         type: string
                     type: object
+                  github:
+                    description: Github configures this store to push Github Action
+                      secrets using Github API provider
+                    properties:
+                      appID:
+                        description: appID specifies the Github APP that will be used
+                          to authenticate the client
+                        format: int64
+                        type: integer
+                      auth:
+                        description: auth configures how secret-manager authenticates
+                          with a Github instance.
+                        properties:
+                          privateKey:
+                            description: |-
+                              A reference to a specific 'key' within a Secret resource.
+                              In some instances, `key` is a required field.
+                            properties:
+                              key:
+                                description: |-
+                                  A key in the referenced Secret.
+                                  Some instances of this field may be defaulted, in others it may be required.
+                                maxLength: 253
+                                minLength: 1
+                                pattern: ^[-._a-zA-Z0-9]+$
+                                type: string
+                              name:
+                                description: The name of the Secret resource being
+                                  referred to.
+                                maxLength: 253
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              namespace:
+                                description: |-
+                                  The namespace of the Secret resource being referred to.
+                                  Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                type: string
+                            type: object
+                        required:
+                        - privateKey
+                        type: object
+                      environment:
+                        description: environment will be used to fetch secrets from
+                          a particular environment within a github repository
+                        type: string
+                      installationID:
+                        description: installationID specifies the Github APP installation
+                          that will be used to authenticate the client
+                        format: int64
+                        type: integer
+                      organization:
+                        description: organization will be used to fetch secrets from
+                          the Github organization
+                        type: string
+                      repository:
+                        description: repository will be used to fetch secrets from
+                          the Github repository within an organization
+                        type: string
+                      uploadURL:
+                        description: Upload URL for enterprise instances. Default
+                          to URL.
+                        type: string
+                      url:
+                        default: https://github.com/
+                        description: URL configures the Github instance URL. Defaults
+                          to https://github.com/.
+                        type: string
+                    required:
+                    - appID
+                    - auth
+                    - installationID
+                    - organization
+                    type: object
                   gitlab:
                     description: GitLab configures this store to sync secrets using
                       GitLab Variables provider
@@ -5565,7 +5642,7 @@ spec:
                                 type: object
                               username:
                                 description: |-
-                                  Username is a LDAP user name used to authenticate using the LDAP Vault
+                                  Username is an LDAP username used to authenticate using the LDAP Vault
                                   authentication method
                                 type: string
                             required:
@@ -5613,10 +5690,10 @@ spec:
                               username/password pair
                             properties:
                               path:
-                                default: user
+                                default: userpass
                                 description: |-
                                   Path where the UserPassword authentication backend is mounted
-                                  in Vault, e.g: "user"
+                                  in Vault, e.g: "userpass"
                                 type: string
                               secretRef:
                                 description: |-
@@ -5650,7 +5727,7 @@ spec:
                                 type: object
                               username:
                                 description: |-
-                                  Username is a user name used to authenticate using the UserPass Vault
+                                  Username is a username used to authenticate using the UserPass Vault
                                   authentication method
                                 type: string
                             required:

--- a/bundle/manifests/external-secrets.io_externalsecrets.yaml
+++ b/bundle/manifests/external-secrets.io_externalsecrets.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   creationTimestamp: null
   labels:
     app: external-secrets

--- a/bundle/manifests/external-secrets.io_pushsecrets.yaml
+++ b/bundle/manifests/external-secrets.io_pushsecrets.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   creationTimestamp: null
   labels:
     app: external-secrets
@@ -112,6 +112,7 @@ spec:
                 - None
                 type: string
               refreshInterval:
+                default: 1h
                 description: The Interval to which External Secrets will try to push
                   a secret definition
                 type: string

--- a/bundle/manifests/external-secrets.io_secretstores.yaml
+++ b/bundle/manifests/external-secrets.io_secretstores.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   creationTimestamp: null
   labels:
     app: external-secrets
@@ -3765,6 +3765,83 @@ spec:
                         description: ProjectID project where secret is located
                         type: string
                     type: object
+                  github:
+                    description: Github configures this store to push Github Action
+                      secrets using Github API provider
+                    properties:
+                      appID:
+                        description: appID specifies the Github APP that will be used
+                          to authenticate the client
+                        format: int64
+                        type: integer
+                      auth:
+                        description: auth configures how secret-manager authenticates
+                          with a Github instance.
+                        properties:
+                          privateKey:
+                            description: |-
+                              A reference to a specific 'key' within a Secret resource.
+                              In some instances, `key` is a required field.
+                            properties:
+                              key:
+                                description: |-
+                                  A key in the referenced Secret.
+                                  Some instances of this field may be defaulted, in others it may be required.
+                                maxLength: 253
+                                minLength: 1
+                                pattern: ^[-._a-zA-Z0-9]+$
+                                type: string
+                              name:
+                                description: The name of the Secret resource being
+                                  referred to.
+                                maxLength: 253
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              namespace:
+                                description: |-
+                                  The namespace of the Secret resource being referred to.
+                                  Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                type: string
+                            type: object
+                        required:
+                        - privateKey
+                        type: object
+                      environment:
+                        description: environment will be used to fetch secrets from
+                          a particular environment within a github repository
+                        type: string
+                      installationID:
+                        description: installationID specifies the Github APP installation
+                          that will be used to authenticate the client
+                        format: int64
+                        type: integer
+                      organization:
+                        description: organization will be used to fetch secrets from
+                          the Github organization
+                        type: string
+                      repository:
+                        description: repository will be used to fetch secrets from
+                          the Github repository within an organization
+                        type: string
+                      uploadURL:
+                        description: Upload URL for enterprise instances. Default
+                          to URL.
+                        type: string
+                      url:
+                        default: https://github.com/
+                        description: URL configures the Github instance URL. Defaults
+                          to https://github.com/.
+                        type: string
+                    required:
+                    - appID
+                    - auth
+                    - installationID
+                    - organization
+                    type: object
                   gitlab:
                     description: GitLab configures this store to sync secrets using
                       GitLab Variables provider
@@ -5565,7 +5642,7 @@ spec:
                                 type: object
                               username:
                                 description: |-
-                                  Username is a LDAP user name used to authenticate using the LDAP Vault
+                                  Username is an LDAP username used to authenticate using the LDAP Vault
                                   authentication method
                                 type: string
                             required:
@@ -5613,10 +5690,10 @@ spec:
                               username/password pair
                             properties:
                               path:
-                                default: user
+                                default: userpass
                                 description: |-
                                   Path where the UserPassword authentication backend is mounted
-                                  in Vault, e.g: "user"
+                                  in Vault, e.g: "userpass"
                                 type: string
                               secretRef:
                                 description: |-
@@ -5650,7 +5727,7 @@ spec:
                                 type: object
                               username:
                                 description: |-
-                                  Username is a user name used to authenticate using the UserPass Vault
+                                  Username is a username used to authenticate using the UserPass Vault
                                   authentication method
                                 type: string
                             required:

--- a/bundle/manifests/generators.external-secrets.io_acraccesstokens.yaml
+++ b/bundle/manifests/generators.external-secrets.io_acraccesstokens.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   creationTimestamp: null
   labels:
     app: external-secrets

--- a/bundle/manifests/generators.external-secrets.io_clustergenerators.yaml
+++ b/bundle/manifests/generators.external-secrets.io_clustergenerators.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   creationTimestamp: null
   labels:
     app: external-secrets
@@ -1414,7 +1414,7 @@ spec:
                                     type: object
                                   username:
                                     description: |-
-                                      Username is a LDAP user name used to authenticate using the LDAP Vault
+                                      Username is an LDAP username used to authenticate using the LDAP Vault
                                       authentication method
                                     type: string
                                 required:
@@ -1462,10 +1462,10 @@ spec:
                                   passing username/password pair
                                 properties:
                                   path:
-                                    default: user
+                                    default: userpass
                                     description: |-
                                       Path where the UserPassword authentication backend is mounted
-                                      in Vault, e.g: "user"
+                                      in Vault, e.g: "userpass"
                                     type: string
                                   secretRef:
                                     description: |-
@@ -1499,7 +1499,7 @@ spec:
                                     type: object
                                   username:
                                     description: |-
-                                      Username is a user name used to authenticate using the UserPass Vault
+                                      Username is a username used to authenticate using the UserPass Vault
                                       authentication method
                                     type: string
                                 required:
@@ -1678,9 +1678,11 @@ spec:
                           When using e.g. /auth/token/create the "data" section is empty but
                           the "auth" section contains the generated token.
                           Please refer to the vault docs regarding the result data structure.
+                          Additionally, accessing the raw response is possibly by using "Raw" result type.
                         enum:
                         - Data
                         - Auth
+                        - Raw
                         type: string
                       retrySettings:
                         description: Used to configure http retries if failed
@@ -1811,7 +1813,8 @@ spec:
                 - Fake
                 - GCRAccessToken
                 - GithubAccessToken
-                - QuayAccessToken'Password
+                - QuayAccessToken
+                - Password
                 - STSSessionToken
                 - UUID
                 - VaultDynamicSecret

--- a/bundle/manifests/generators.external-secrets.io_ecrauthorizationtokens.yaml
+++ b/bundle/manifests/generators.external-secrets.io_ecrauthorizationtokens.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   creationTimestamp: null
   labels:
     app: external-secrets

--- a/bundle/manifests/generators.external-secrets.io_gcraccesstokens.yaml
+++ b/bundle/manifests/generators.external-secrets.io_gcraccesstokens.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   creationTimestamp: null
   labels:
     app: external-secrets

--- a/bundle/manifests/generators.external-secrets.io_generatorstates.yaml
+++ b/bundle/manifests/generators.external-secrets.io_generatorstates.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   creationTimestamp: null
   labels:
     app: external-secrets

--- a/bundle/manifests/generators.external-secrets.io_githubaccesstokens.yaml
+++ b/bundle/manifests/generators.external-secrets.io_githubaccesstokens.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   creationTimestamp: null
   labels:
     app: external-secrets

--- a/bundle/manifests/generators.external-secrets.io_grafanas.yaml
+++ b/bundle/manifests/generators.external-secrets.io_grafanas.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   creationTimestamp: null
   labels:
     app: external-secrets

--- a/bundle/manifests/generators.external-secrets.io_passwords.yaml
+++ b/bundle/manifests/generators.external-secrets.io_passwords.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   creationTimestamp: null
   labels:
     app: external-secrets

--- a/bundle/manifests/generators.external-secrets.io_quayaccesstokens.yaml
+++ b/bundle/manifests/generators.external-secrets.io_quayaccesstokens.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   creationTimestamp: null
   labels:
     app: external-secrets

--- a/bundle/manifests/generators.external-secrets.io_stssessiontokens.yaml
+++ b/bundle/manifests/generators.external-secrets.io_stssessiontokens.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   creationTimestamp: null
   labels:
     app: external-secrets

--- a/bundle/manifests/generators.external-secrets.io_uuids.yaml
+++ b/bundle/manifests/generators.external-secrets.io_uuids.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   creationTimestamp: null
   labels:
     app: external-secrets

--- a/bundle/manifests/generators.external-secrets.io_vaultdynamicsecrets.yaml
+++ b/bundle/manifests/generators.external-secrets.io_vaultdynamicsecrets.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   creationTimestamp: null
   labels:
     app: external-secrets
@@ -610,7 +610,7 @@ spec:
                             type: object
                           username:
                             description: |-
-                              Username is a LDAP user name used to authenticate using the LDAP Vault
+                              Username is an LDAP username used to authenticate using the LDAP Vault
                               authentication method
                             type: string
                         required:
@@ -658,10 +658,10 @@ spec:
                           username/password pair
                         properties:
                           path:
-                            default: user
+                            default: userpass
                             description: |-
                               Path where the UserPassword authentication backend is mounted
-                              in Vault, e.g: "user"
+                              in Vault, e.g: "userpass"
                             type: string
                           secretRef:
                             description: |-
@@ -695,7 +695,7 @@ spec:
                             type: object
                           username:
                             description: |-
-                              Username is a user name used to authenticate using the UserPass Vault
+                              Username is a username used to authenticate using the UserPass Vault
                               authentication method
                             type: string
                         required:
@@ -874,9 +874,11 @@ spec:
                   When using e.g. /auth/token/create the "data" section is empty but
                   the "auth" section contains the generated token.
                   Please refer to the vault docs regarding the result data structure.
+                  Additionally, accessing the raw response is possibly by using "Raw" result type.
                 enum:
                 - Data
                 - Auth
+                - Raw
                 type: string
               retrySettings:
                 description: Used to configure http retries if failed

--- a/bundle/manifests/generators.external-secrets.io_webhooks.yaml
+++ b/bundle/manifests/generators.external-secrets.io_webhooks.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   creationTimestamp: null
   labels:
     app: external-secrets

--- a/config/crd/bases/customresourcedefinition_acraccesstokens.generators.external-secrets.io.yml
+++ b/config/crd/bases/customresourcedefinition_acraccesstokens.generators.external-secrets.io.yml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   labels:
     external-secrets.io/component: controller
     app: external-secrets

--- a/config/crd/bases/customresourcedefinition_clusterexternalsecrets.external-secrets.io.yml
+++ b/config/crd/bases/customresourcedefinition_clusterexternalsecrets.external-secrets.io.yml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   labels:
     external-secrets.io/component: controller
     app: external-secrets

--- a/config/crd/bases/customresourcedefinition_clustergenerators.generators.external-secrets.io.yml
+++ b/config/crd/bases/customresourcedefinition_clustergenerators.generators.external-secrets.io.yml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   labels:
     external-secrets.io/component: controller
     app: external-secrets
@@ -1335,7 +1335,7 @@ spec:
                                       type: object
                                     username:
                                       description: |-
-                                        Username is a LDAP user name used to authenticate using the LDAP Vault
+                                        Username is an LDAP username used to authenticate using the LDAP Vault
                                         authentication method
                                       type: string
                                   required:
@@ -1380,10 +1380,10 @@ spec:
                                   description: UserPass authenticates with Vault by passing username/password pair
                                   properties:
                                     path:
-                                      default: user
+                                      default: userpass
                                       description: |-
                                         Path where the UserPassword authentication backend is mounted
-                                        in Vault, e.g: "user"
+                                        in Vault, e.g: "userpass"
                                       type: string
                                     secretRef:
                                       description: |-
@@ -1416,7 +1416,7 @@ spec:
                                       type: object
                                     username:
                                       description: |-
-                                        Username is a user name used to authenticate using the UserPass Vault
+                                        Username is a username used to authenticate using the UserPass Vault
                                         authentication method
                                       type: string
                                   required:
@@ -1588,9 +1588,11 @@ spec:
                             When using e.g. /auth/token/create the "data" section is empty but
                             the "auth" section contains the generated token.
                             Please refer to the vault docs regarding the result data structure.
+                            Additionally, accessing the raw response is possibly by using "Raw" result type.
                           enum:
                             - Data
                             - Auth
+                            - Raw
                           type: string
                         retrySettings:
                           description: Used to configure http retries if failed
@@ -1714,7 +1716,8 @@ spec:
                     - Fake
                     - GCRAccessToken
                     - GithubAccessToken
-                    - QuayAccessToken'Password
+                    - QuayAccessToken
+                    - Password
                     - STSSessionToken
                     - UUID
                     - VaultDynamicSecret

--- a/config/crd/bases/customresourcedefinition_clustersecretstores.external-secrets.io.yml
+++ b/config/crd/bases/customresourcedefinition_clustersecretstores.external-secrets.io.yml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   labels:
     external-secrets.io/component: controller
     app: external-secrets
@@ -3533,6 +3533,73 @@ spec:
                           description: ProjectID project where secret is located
                           type: string
                       type: object
+                    github:
+                      description: Github configures this store to push Github Action secrets using Github API provider
+                      properties:
+                        appID:
+                          description: appID specifies the Github APP that will be used to authenticate the client
+                          format: int64
+                          type: integer
+                        auth:
+                          description: auth configures how secret-manager authenticates with a Github instance.
+                          properties:
+                            privateKey:
+                              description: |-
+                                A reference to a specific 'key' within a Secret resource.
+                                In some instances, `key` is a required field.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          required:
+                            - privateKey
+                          type: object
+                        environment:
+                          description: environment will be used to fetch secrets from a particular environment within a github repository
+                          type: string
+                        installationID:
+                          description: installationID specifies the Github APP installation that will be used to authenticate the client
+                          format: int64
+                          type: integer
+                        organization:
+                          description: organization will be used to fetch secrets from the Github organization
+                          type: string
+                        repository:
+                          description: repository will be used to fetch secrets from the Github repository within an organization
+                          type: string
+                        uploadURL:
+                          description: Upload URL for enterprise instances. Default to URL.
+                          type: string
+                        url:
+                          default: https://github.com/
+                          description: URL configures the Github instance URL. Defaults to https://github.com/.
+                          type: string
+                      required:
+                        - appID
+                        - auth
+                        - installationID
+                        - organization
+                      type: object
                     gitlab:
                       description: GitLab configures this store to sync secrets using GitLab Variables provider
                       properties:
@@ -5220,7 +5287,7 @@ spec:
                                   type: object
                                 username:
                                   description: |-
-                                    Username is a LDAP user name used to authenticate using the LDAP Vault
+                                    Username is an LDAP username used to authenticate using the LDAP Vault
                                     authentication method
                                   type: string
                               required:
@@ -5265,10 +5332,10 @@ spec:
                               description: UserPass authenticates with Vault by passing username/password pair
                               properties:
                                 path:
-                                  default: user
+                                  default: userpass
                                   description: |-
                                     Path where the UserPassword authentication backend is mounted
-                                    in Vault, e.g: "user"
+                                    in Vault, e.g: "userpass"
                                   type: string
                                 secretRef:
                                   description: |-
@@ -5301,7 +5368,7 @@ spec:
                                   type: object
                                 username:
                                   description: |-
-                                    Username is a user name used to authenticate using the UserPass Vault
+                                    Username is a username used to authenticate using the UserPass Vault
                                     authentication method
                                   type: string
                               required:

--- a/config/crd/bases/customresourcedefinition_ecrauthorizationtokens.generators.external-secrets.io.yml
+++ b/config/crd/bases/customresourcedefinition_ecrauthorizationtokens.generators.external-secrets.io.yml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   labels:
     external-secrets.io/component: controller
     app: external-secrets

--- a/config/crd/bases/customresourcedefinition_externalsecrets.external-secrets.io.yml
+++ b/config/crd/bases/customresourcedefinition_externalsecrets.external-secrets.io.yml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   labels:
     external-secrets.io/component: controller
     app: external-secrets

--- a/config/crd/bases/customresourcedefinition_gcraccesstokens.generators.external-secrets.io.yml
+++ b/config/crd/bases/customresourcedefinition_gcraccesstokens.generators.external-secrets.io.yml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   labels:
     external-secrets.io/component: controller
     app: external-secrets

--- a/config/crd/bases/customresourcedefinition_generatorstates.generators.external-secrets.io.yml
+++ b/config/crd/bases/customresourcedefinition_generatorstates.generators.external-secrets.io.yml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   labels:
     external-secrets.io/component: controller
     app: external-secrets

--- a/config/crd/bases/customresourcedefinition_githubaccesstokens.generators.external-secrets.io.yml
+++ b/config/crd/bases/customresourcedefinition_githubaccesstokens.generators.external-secrets.io.yml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   labels:
     external-secrets.io/component: controller
     app: external-secrets

--- a/config/crd/bases/customresourcedefinition_grafanas.generators.external-secrets.io.yml
+++ b/config/crd/bases/customresourcedefinition_grafanas.generators.external-secrets.io.yml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   labels:
     external-secrets.io/component: controller
     app: external-secrets

--- a/config/crd/bases/customresourcedefinition_passwords.generators.external-secrets.io.yml
+++ b/config/crd/bases/customresourcedefinition_passwords.generators.external-secrets.io.yml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   labels:
     external-secrets.io/component: controller
     app: external-secrets

--- a/config/crd/bases/customresourcedefinition_pushsecrets.external-secrets.io.yml
+++ b/config/crd/bases/customresourcedefinition_pushsecrets.external-secrets.io.yml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   labels:
     external-secrets.io/component: controller
     app: external-secrets
@@ -101,6 +101,7 @@ spec:
                     - None
                   type: string
                 refreshInterval:
+                  default: 1h
                   description: The Interval to which External Secrets will try to push a secret definition
                   type: string
                 secretStoreRefs:

--- a/config/crd/bases/customresourcedefinition_quayaccesstokens.generators.external-secrets.io.yml
+++ b/config/crd/bases/customresourcedefinition_quayaccesstokens.generators.external-secrets.io.yml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   labels:
     external-secrets.io/component: controller
     app: external-secrets

--- a/config/crd/bases/customresourcedefinition_secretstores.external-secrets.io.yml
+++ b/config/crd/bases/customresourcedefinition_secretstores.external-secrets.io.yml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   labels:
     external-secrets.io/component: controller
     app: external-secrets
@@ -3533,6 +3533,73 @@ spec:
                           description: ProjectID project where secret is located
                           type: string
                       type: object
+                    github:
+                      description: Github configures this store to push Github Action secrets using Github API provider
+                      properties:
+                        appID:
+                          description: appID specifies the Github APP that will be used to authenticate the client
+                          format: int64
+                          type: integer
+                        auth:
+                          description: auth configures how secret-manager authenticates with a Github instance.
+                          properties:
+                            privateKey:
+                              description: |-
+                                A reference to a specific 'key' within a Secret resource.
+                                In some instances, `key` is a required field.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          required:
+                            - privateKey
+                          type: object
+                        environment:
+                          description: environment will be used to fetch secrets from a particular environment within a github repository
+                          type: string
+                        installationID:
+                          description: installationID specifies the Github APP installation that will be used to authenticate the client
+                          format: int64
+                          type: integer
+                        organization:
+                          description: organization will be used to fetch secrets from the Github organization
+                          type: string
+                        repository:
+                          description: repository will be used to fetch secrets from the Github repository within an organization
+                          type: string
+                        uploadURL:
+                          description: Upload URL for enterprise instances. Default to URL.
+                          type: string
+                        url:
+                          default: https://github.com/
+                          description: URL configures the Github instance URL. Defaults to https://github.com/.
+                          type: string
+                      required:
+                        - appID
+                        - auth
+                        - installationID
+                        - organization
+                      type: object
                     gitlab:
                       description: GitLab configures this store to sync secrets using GitLab Variables provider
                       properties:
@@ -5220,7 +5287,7 @@ spec:
                                   type: object
                                 username:
                                   description: |-
-                                    Username is a LDAP user name used to authenticate using the LDAP Vault
+                                    Username is an LDAP username used to authenticate using the LDAP Vault
                                     authentication method
                                   type: string
                               required:
@@ -5265,10 +5332,10 @@ spec:
                               description: UserPass authenticates with Vault by passing username/password pair
                               properties:
                                 path:
-                                  default: user
+                                  default: userpass
                                   description: |-
                                     Path where the UserPassword authentication backend is mounted
-                                    in Vault, e.g: "user"
+                                    in Vault, e.g: "userpass"
                                   type: string
                                 secretRef:
                                   description: |-
@@ -5301,7 +5368,7 @@ spec:
                                   type: object
                                 username:
                                   description: |-
-                                    Username is a user name used to authenticate using the UserPass Vault
+                                    Username is a username used to authenticate using the UserPass Vault
                                     authentication method
                                   type: string
                               required:

--- a/config/crd/bases/customresourcedefinition_stssessiontokens.generators.external-secrets.io.yml
+++ b/config/crd/bases/customresourcedefinition_stssessiontokens.generators.external-secrets.io.yml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   labels:
     external-secrets.io/component: controller
     app: external-secrets

--- a/config/crd/bases/customresourcedefinition_uuids.generators.external-secrets.io.yml
+++ b/config/crd/bases/customresourcedefinition_uuids.generators.external-secrets.io.yml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   labels:
     external-secrets.io/component: controller
     app: external-secrets

--- a/config/crd/bases/customresourcedefinition_vaultdynamicsecrets.generators.external-secrets.io.yml
+++ b/config/crd/bases/customresourcedefinition_vaultdynamicsecrets.generators.external-secrets.io.yml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   labels:
     external-secrets.io/component: controller
     app: external-secrets
@@ -577,7 +577,7 @@ spec:
                               type: object
                             username:
                               description: |-
-                                Username is a LDAP user name used to authenticate using the LDAP Vault
+                                Username is an LDAP username used to authenticate using the LDAP Vault
                                 authentication method
                               type: string
                           required:
@@ -622,10 +622,10 @@ spec:
                           description: UserPass authenticates with Vault by passing username/password pair
                           properties:
                             path:
-                              default: user
+                              default: userpass
                               description: |-
                                 Path where the UserPassword authentication backend is mounted
-                                in Vault, e.g: "user"
+                                in Vault, e.g: "userpass"
                               type: string
                             secretRef:
                               description: |-
@@ -658,7 +658,7 @@ spec:
                               type: object
                             username:
                               description: |-
-                                Username is a user name used to authenticate using the UserPass Vault
+                                Username is a username used to authenticate using the UserPass Vault
                                 authentication method
                               type: string
                           required:
@@ -830,9 +830,11 @@ spec:
                     When using e.g. /auth/token/create the "data" section is empty but
                     the "auth" section contains the generated token.
                     Please refer to the vault docs regarding the result data structure.
+                    Additionally, accessing the raw response is possibly by using "Raw" result type.
                   enum:
                     - Data
                     - Auth
+                    - Raw
                   type: string
                 retrySettings:
                   description: Used to configure http retries if failed

--- a/config/crd/bases/customresourcedefinition_webhooks.generators.external-secrets.io.yml
+++ b/config/crd/bases/customresourcedefinition_webhooks.generators.external-secrets.io.yml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   labels:
     external-secrets.io/component: controller
     app: external-secrets

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -152,7 +152,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets-webhook
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v0.14.0"
+    app.kubernetes.io/version: "v0.14.3"
     app.kubernetes.io/managed-by: external-secrets-operator
     external-secrets.io/component: webhook
 spec:
@@ -192,7 +192,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets-cert-controller
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v0.14.0"
+    app.kubernetes.io/version: "v0.14.3"
     app.kubernetes.io/managed-by: external-secrets-operator
 rules:
   - apiGroups:
@@ -282,7 +282,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v0.14.0"
+    app.kubernetes.io/version: "v0.14.3"
     app.kubernetes.io/managed-by: external-secrets-operator
 rules:
   - apiGroups:
@@ -427,7 +427,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v0.14.0"
+    app.kubernetes.io/version: "v0.14.3"
     app.kubernetes.io/managed-by: external-secrets-operator
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
@@ -492,7 +492,7 @@ metadata:
     servicebinding.io/controller: "true"
     app.kubernetes.io/name: external-secrets
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v0.14.0"
+    app.kubernetes.io/version: "v0.14.3"
     app.kubernetes.io/managed-by: external-secrets-operator
 rules:
   - apiGroups:
@@ -528,7 +528,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v0.14.0"
+    app.kubernetes.io/version: "v0.14.3"
     app.kubernetes.io/managed-by: external-secrets-operator
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
@@ -589,7 +589,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets-cert-controller
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v0.14.0"
+    app.kubernetes.io/version: "v0.14.3"
     app.kubernetes.io/managed-by: external-secrets-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -624,7 +624,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v0.14.0"
+    app.kubernetes.io/version: "v0.14.3"
     app.kubernetes.io/managed-by: external-secrets-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -735,7 +735,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets-cert-controller
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v0.14.0"
+    app.kubernetes.io/version: "v0.14.3"
     app.kubernetes.io/managed-by: external-secrets-operator
 spec:
   replicas: 1
@@ -749,7 +749,7 @@ spec:
       labels:
         app.kubernetes.io/name: external-secrets-cert-controller
         app.kubernetes.io/instance: external-secrets
-        app.kubernetes.io/version: "v0.14.0"
+        app.kubernetes.io/version: "v0.14.3"
         app.kubernetes.io/managed-by: external-secrets-operator
     spec:
       serviceAccountName: external-secrets-cert-controller
@@ -767,7 +767,7 @@ spec:
             runAsUser: 1000
             seccompProfile:
               type: RuntimeDefault
-          image: oci.external-secrets.io/external-secrets/external-secrets:v0.14.0
+          image: oci.external-secrets.io/external-secrets/external-secrets:v0.14.3
           imagePullPolicy: IfNotPresent
           args:
             - certcontroller
@@ -817,7 +817,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets-webhook
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v0.14.0"
+    app.kubernetes.io/version: "v0.14.3"
     app.kubernetes.io/managed-by: external-secrets-operator
 spec:
   replicas: 1
@@ -831,7 +831,7 @@ spec:
       labels:
         app.kubernetes.io/name: external-secrets-webhook
         app.kubernetes.io/instance: external-secrets
-        app.kubernetes.io/version: "v0.14.0"
+        app.kubernetes.io/version: "v0.14.3"
         app.kubernetes.io/managed-by: external-secrets-operator
     spec:
       hostNetwork: false
@@ -849,7 +849,7 @@ spec:
             runAsUser: 1000
             seccompProfile:
               type: RuntimeDefault
-          image: oci.external-secrets.io/external-secrets/external-secrets:v0.14.0
+          image: oci.external-secrets.io/external-secrets/external-secrets:v0.14.3
           imagePullPolicy: IfNotPresent
           args:
             - webhook
@@ -908,7 +908,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v0.14.0"
+    app.kubernetes.io/version: "v0.14.3"
     app.kubernetes.io/managed-by: external-secrets-operator
 spec:
   replicas: 1
@@ -922,7 +922,7 @@ spec:
       labels:
         app.kubernetes.io/name: external-secrets
         app.kubernetes.io/instance: external-secrets
-        app.kubernetes.io/version: "v0.14.0"
+        app.kubernetes.io/version: "v0.14.3"
         app.kubernetes.io/managed-by: external-secrets-operator
     spec:
       serviceAccountName: external-secrets
@@ -940,7 +940,7 @@ spec:
             runAsUser: 1000
             seccompProfile:
               type: RuntimeDefault
-          image: oci.external-secrets.io/external-secrets/external-secrets:v0.14.0
+          image: oci.external-secrets.io/external-secrets/external-secrets:v0.14.3
           imagePullPolicy: IfNotPresent
           args:
             - --concurrent=1
@@ -982,7 +982,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v0.14.0"
+    app.kubernetes.io/version: "v0.14.3"
     app.kubernetes.io/managed-by: external-secrets-operator
 rules:
   - apiGroups:
@@ -1036,7 +1036,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v0.14.0"
+    app.kubernetes.io/version: "v0.14.3"
     app.kubernetes.io/managed-by: external-secrets-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1072,7 +1072,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets-webhook
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v0.14.0"
+    app.kubernetes.io/version: "v0.14.3"
     app.kubernetes.io/managed-by: external-secrets-operator
     external-secrets.io/component: webhook
 `)
@@ -1137,7 +1137,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets-webhook
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v0.14.0"
+    app.kubernetes.io/version: "v0.14.3"
     app.kubernetes.io/managed-by: external-secrets-operator
     external-secrets.io/component: webhook
 spec:
@@ -1203,7 +1203,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets-cert-controller
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v0.14.0"
+    app.kubernetes.io/version: "v0.14.3"
     app.kubernetes.io/managed-by: external-secrets-operator
 `)
 
@@ -1231,7 +1231,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets-webhook
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v0.14.0"
+    app.kubernetes.io/version: "v0.14.3"
     app.kubernetes.io/managed-by: external-secrets-operator
 `)
 
@@ -1259,7 +1259,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v0.14.0"
+    app.kubernetes.io/version: "v0.14.3"
     app.kubernetes.io/managed-by: external-secrets-operator
 `)
 
@@ -1286,7 +1286,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets-webhook
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v0.14.0"
+    app.kubernetes.io/version: "v0.14.3"
     app.kubernetes.io/managed-by: external-secrets-operator
     external-secrets.io/component: webhook
 webhooks:
@@ -1331,7 +1331,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets-webhook
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v0.14.0"
+    app.kubernetes.io/version: "v0.14.3"
     app.kubernetes.io/managed-by: external-secrets-operator
     external-secrets.io/component: webhook
 webhooks:


### PR DESCRIPTION
This PR is for updating the CRDs of `external-secrets` operand to `v0.14.3` which is required for [OCPBUGS-57833](https://issues.redhat.com/browse/OCPBUGS-57833).