### PR TITLE
ESO-2: Detects and reconciles changes to annotations in webhook resource

### DIFF
--- a/pkg/controller/common/utils.go
+++ b/pkg/controller/common/utils.go
@@ -343,6 +343,12 @@ func validatingWebHookSpecModified(desired, fetched *webhook.ValidatingWebhookCo
 		return true
 	}
 
+	if desiredVal, exists := desired.GetAnnotations()[CertManagerInjectCAFromAnnotation]; exists {
+		if desiredVal != fetched.GetAnnotations()[CertManagerInjectCAFromAnnotation] {
+			return true
+		}
+	}
+
 	fetchedWebhooksMap := make(map[string]webhook.ValidatingWebhook)
 	for _, wh := range fetched.Webhooks {
 		fetchedWebhooksMap[wh.Name] = wh

--- a/pkg/controller/external_secrets/deployments.go
+++ b/pkg/controller/external_secrets/deployments.go
@@ -126,7 +126,7 @@ func (r *Reconciler) getDeploymentObject(assetName string, externalsecrets *oper
 	case certControllerDeploymentAssetName:
 		updateCertControllerContainerSpec(deployment, image, logLevel)
 	case bitwardenDeploymentAssetName:
-		deployment.ObjectMeta.Labels["app.kubernetes.io/version"] = bitwardenImageVersionEnvVarName
+		deployment.Labels["app.kubernetes.io/version"] = bitwardenImageVersionEnvVarName
 		updateBitwardenServerContainerSpec(deployment, bitwardenImage)
 	}
 


### PR DESCRIPTION
The PR has following changes
- Controller now detects changes(update/deleted) to expected annotations in `ValidatingWebhookConfiguration` resource created for `external-secrets` operand and reconciles it back to desired state.
- Removes explicit mention of embedded field name `ObjectMeta` in path for reading `Labels` field, which is redundant.