### PR TITLE
ESO-167: Removes resources created for cert-controller component when cert-manager is enabled

### DIFF
--- a/bundle/manifests/external-secrets-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/external-secrets-operator.clusterserviceversion.yaml
@@ -204,7 +204,7 @@ metadata:
     categories: Security
     console.openshift.io/disable-operand-delete: "true"
     containerImage: openshift.io/external-secrets-operator:latest
-    createdAt: "2025-08-18T11:50:12Z"
+    createdAt: "2025-08-20T18:17:42Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -403,6 +403,7 @@ spec:
           - deployments
           verbs:
           - create
+          - delete
           - get
           - list
           - update

--- a/bundle/manifests/operator.openshift.io_externalsecrets.yaml
+++ b/bundle/manifests/operator.openshift.io_externalsecrets.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.17.3
   creationTimestamp: null
   name: externalsecrets.operator.openshift.io
 spec:

--- a/bundle/manifests/operator.openshift.io_externalsecretsmanagers.yaml
+++ b/bundle/manifests/operator.openshift.io_externalsecretsmanagers.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.17.3
   creationTimestamp: null
   name: externalsecretsmanagers.operator.openshift.io
 spec:

--- a/config/crd/bases/operator.openshift.io_externalsecrets.yaml
+++ b/config/crd/bases/operator.openshift.io_externalsecrets.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: externalsecrets.operator.openshift.io
 spec:
   group: operator.openshift.io

--- a/config/crd/bases/operator.openshift.io_externalsecretsmanagers.yaml
+++ b/config/crd/bases/operator.openshift.io_externalsecretsmanagers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: externalsecretsmanagers.operator.openshift.io
 spec:
   group: operator.openshift.io

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -65,6 +65,7 @@ rules:
   - deployments
   verbs:
   - create
+  - delete
   - get
   - list
   - update

--- a/pkg/controller/common/utils.go
+++ b/pkg/controller/common/utils.go
@@ -12,6 +12,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	crdv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/types"
@@ -22,6 +23,7 @@ import (
 
 	operatorv1alpha1 "github.com/openshift/external-secrets-operator/api/v1alpha1"
 	operatorclient "github.com/openshift/external-secrets-operator/pkg/controller/client"
+	"github.com/openshift/external-secrets-operator/pkg/operator/assets"
 )
 
 var (
@@ -459,4 +461,36 @@ func (n *Now) Reset() {
 	defer n.Unlock()
 
 	n.done.Store(0)
+}
+
+// DeleteObject is for deleting an object mentioned in the asset file passed.
+// Does not treat NotFound as an error, and can be extended in future with arg, whether to
+// return an error.
+// TODO: Extend for other object types as and when required.
+func DeleteObject(ctx context.Context, ctrlClient operatorclient.CtrlClient, obj client.Object, assetName string) error {
+	var o client.Object
+	switch obj.(type) {
+	case *rbacv1.ClusterRole:
+		o = DecodeClusterRoleObjBytes(assets.MustAsset(assetName))
+	case *rbacv1.ClusterRoleBinding:
+		o = DecodeClusterRoleBindingObjBytes(assets.MustAsset(assetName))
+	case *appsv1.Deployment:
+		o = DecodeDeploymentObjBytes(assets.MustAsset(assetName))
+	case *corev1.Secret:
+		o = DecodeSecretObjBytes(assets.MustAsset(assetName))
+	case *corev1.ServiceAccount:
+		o = DecodeServiceAccountObjBytes(assets.MustAsset(assetName))
+	default:
+		panic(fmt.Sprintf("unsupported object type: %T", obj))
+	}
+	exists, err := ctrlClient.Exists(ctx, types.NamespacedName{Name: o.GetName(), Namespace: o.GetNamespace()}, o)
+	if err != nil {
+		return err
+	}
+	if exists {
+		if err := ctrlClient.Delete(ctx, o); err != nil && !errors.IsNotFound(err) {
+			return err
+		}
+	}
+	return nil
 }

--- a/pkg/controller/external_secrets/controller.go
+++ b/pkg/controller/external_secrets/controller.go
@@ -99,7 +99,7 @@ type Reconciler struct {
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings;clusterroles;clusterrolebindings,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingwebhookconfigurations,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups="",resources=events;secrets;services;serviceaccounts,verbs=get;list;watch;create;update;delete;patch
-// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=cert-manager.io,resources=certificates;clusterissuers;issuers,verbs=get;list;watch;create;update
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch;create
 

--- a/pkg/controller/external_secrets/deployments.go
+++ b/pkg/controller/external_secrets/deployments.go
@@ -48,6 +48,9 @@ func (r *Reconciler) createOrApplyDeployments(externalsecrets *operatorv1alpha1.
 	// Apply deployments based on the specified conditions.
 	for _, d := range deployments {
 		if !d.condition {
+			if err := common.DeleteObject(r.ctx, r.CtrlClient, &appsv1.Deployment{}, d.assetName); err != nil {
+				return fmt.Errorf("failed to delete deployment resource: %w", err)
+			}
 			continue
 		}
 		if err := r.createOrApplyDeploymentFromAsset(externalsecrets, d.assetName, resourceLabels, externalsecretsCreateRecon); err != nil {

--- a/pkg/controller/external_secrets/secret.go
+++ b/pkg/controller/external_secrets/secret.go
@@ -14,7 +14,10 @@ import (
 func (r *Reconciler) createOrApplySecret(es *operatorv1alpha1.ExternalSecrets, resourceLabels map[string]string, recon bool) error {
 	// secrets are only created if isCertManagerConfig is not enabled
 	if isCertManagerConfigEnabled(es) {
-		r.log.V(4).Info("cert-manager config is enabled, skipping webhook component secret resource creation")
+		r.log.V(4).Info("cert-manager config is enabled, deleting webhook component secret resource if exists")
+		if err := common.DeleteObject(r.ctx, r.CtrlClient, &corev1.Secret{}, webhookTLSSecretAssetName); err != nil {
+			return fmt.Errorf("failed to delete secret resource of webhook component: %w", err)
+		}
 		return nil
 	}
 

--- a/pkg/controller/external_secrets/serviceaccounts.go
+++ b/pkg/controller/external_secrets/serviceaccounts.go
@@ -37,6 +37,9 @@ func (r *Reconciler) createOrApplyServiceAccounts(externalsecrets *operatorv1alp
 
 	for _, serviceAccount := range serviceAccountsToCreate {
 		if !serviceAccount.condition {
+			if err := common.DeleteObject(r.ctx, r.CtrlClient, &corev1.ServiceAccount{}, serviceAccount.assetName); err != nil {
+				return fmt.Errorf("failed to delete cert-controller serviceaccount: %w", err)
+			}
 			continue
 		}
 

--- a/pkg/controller/external_secrets/serviceaccounts_test.go
+++ b/pkg/controller/external_secrets/serviceaccounts_test.go
@@ -116,6 +116,30 @@ func TestCreateOrApplyServiceAccounts(t *testing.T) {
 			},
 			wantErr: "failed to create serviceaccount external-secrets/external-secrets: test client error",
 		},
+		{
+			name: "cert-controller serviceaccount skipped when cert-manager enabled",
+			preReq: func(r *Reconciler, m *fakes.FakeCtrlClient) {
+				m.ExistsCalls(func(ctx context.Context, ns types.NamespacedName, obj client.Object) (bool, error) {
+					switch o := obj.(type) {
+					case *corev1.ServiceAccount:
+						sa := testServiceAccount(certControllerServiceAccountAssetName)
+						sa.DeepCopyInto(o)
+					}
+					return true, nil
+				})
+				m.DeleteCalls(func(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+					return commontest.TestClientError
+				})
+			},
+			updateExternalSecretsObj: func(es *operatorv1alpha1.ExternalSecrets) {
+				es.Spec.ExternalSecretsConfig = &operatorv1alpha1.ExternalSecretsConfig{
+					CertManagerConfig: &operatorv1alpha1.CertManagerConfig{
+						Enabled: "true",
+					},
+				}
+			},
+			wantErr: `failed to delete cert-controller serviceaccount: test client error`,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
PR is for removing resources created external-secrets cert-controller component, when `externalsecrets.operator.openshift.io.spec.externalSecretsConfig.certManagerConfig` is enabled, which otherwise causes conflict and the `external-secrets` will be in degraded condition.
Below resources will deleted, if exists, when cert-manager is configured:
- ClusterRole
- ClusterRoleBinding
- Deployment
- Secret
- ServiceAccount

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically cleans up unused cert-controller components (deployments, RBAC, service accounts, secrets) when cert-manager is enabled.

* **Chores**
  * Updated operator permissions to include deleting deployments.
  * Refreshed CRD/CSV metadata annotations; no schema or runtime behavior changes.

* **Tests**
  * Added tests covering deletion flows and NotFound handling for deployments, RBAC, service accounts, and secrets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->