### PR TITLE
ESO-421:API Implementation of Egress proxy network policy.

### DIFF
--- a/api/v1alpha1/external_secrets_config_types.go
+++ b/api/v1alpha1/external_secrets_config_types.go
@@ -137,6 +137,7 @@ type ControllerConfig struct {
 	//
 	// Each entry allows specifying a name for the generated NetworkPolicy object,
 	// along with its full Kubernetes NetworkPolicy definition.
+	// The operator prepends "eso-user-" to the provided name when creating the Kubernetes object.
 	//
 	// If this field is not provided, external-secrets components will be isolated
 	// with deny-all network policies, which will prevent proper operation.
@@ -299,8 +300,9 @@ const (
 // NetworkPolicy represents a custom network policy configuration for operator-managed components.
 // It includes a name for identification and the network policy rules to be enforced.
 type NetworkPolicy struct {
-	// name is a unique identifier for this network policy configuration.
-	// This name will be used as part of the generated NetworkPolicy resource name.
+	// Name is the logical identifier for this network policy entry.
+	// The operator prepends "eso-user-" to this value when creating the Kubernetes
+	// NetworkPolicy object (e.g. "allow-egress" becomes "eso-user-allow-egress").
 	// +kubebuilder:validation:MinLength:=1
 	// +kubebuilder:validation:MaxLength:=253
 	// +required

--- a/api/v1alpha1/meta.go
+++ b/api/v1alpha1/meta.go
@@ -111,7 +111,28 @@ type ProxyConfig struct {
 	// +kubebuilder:validation:MaxLength:=4096
 	// +optional
 	NoProxy string `json:"noProxy,omitempty"`
+
+	// NetworkPolicyProvisioning defines the management strategy for the proxy egress rule.
+	// When set to Managed, the operator automatically provisions and maintains
+	// a NetworkPolicy allowing traffic to the configured proxy.
+	// If no proxy is configured, no NetworkPolicy will be created
+	// regardless of this setting.
+	// +kubebuilder:validation:Enum=Managed;Unmanaged
+	// +kubebuilder:default=Managed
+	// +optional
+	NetworkPolicyProvisioning ManagementState `json:"networkPolicyProvisioning,omitempty"`
 }
+
+// ManagementState controls whether the operator manages the resource lifecycle.
+type ManagementState string
+
+const (
+	// ManagementStateManaged indicates the Operator is responsible for the resource lifecycle.
+	ManagementStateManaged ManagementState = "Managed"
+
+	// ManagementStateUnmanaged indicates the User is responsible for the resource lifecycle.
+	ManagementStateUnmanaged ManagementState = "Unmanaged"
+)
 
 // Mode indicates the operational state of the optional features.
 type Mode string

--- a/api/v1alpha1/tests/externalsecretsconfig.operator.openshift.io/externalsecretsconfig.testsuite.yaml
+++ b/api/v1alpha1/tests/externalsecretsconfig.operator.openshift.io/externalsecretsconfig.testsuite.yaml
@@ -1445,6 +1445,96 @@ tests:
                 injectAnnotations: "false"
                 certificateDuration: "8760h"
                 certificateRenewBefore: "30m"
+    - name: Should accept networkPolicyProvisioning set to Managed (default)
+      resourceName: cluster
+      initial: |
+        apiVersion: operator.openshift.io/v1alpha1
+        kind: ExternalSecretsConfig
+        spec:
+          appConfig:
+            proxy:
+              httpProxy: "http://proxy.example.com:3128"
+              networkPolicyProvisioning: Managed
+      expected: |
+        apiVersion: operator.openshift.io/v1alpha1
+        kind: ExternalSecretsConfig
+        spec:
+          appConfig:
+            logLevel: 1
+            proxy:
+              httpProxy: "http://proxy.example.com:3128"
+              networkPolicyProvisioning: Managed
+    - name: Should accept networkPolicyProvisioning set to Unmanaged
+      resourceName: cluster
+      initial: |
+        apiVersion: operator.openshift.io/v1alpha1
+        kind: ExternalSecretsConfig
+        spec:
+          appConfig:
+            proxy:
+              httpProxy: "http://proxy.example.com:3128"
+              networkPolicyProvisioning: Unmanaged
+      expected: |
+        apiVersion: operator.openshift.io/v1alpha1
+        kind: ExternalSecretsConfig
+        spec:
+          appConfig:
+            logLevel: 1
+            proxy:
+              httpProxy: "http://proxy.example.com:3128"
+              networkPolicyProvisioning: Unmanaged
+    - name: Should default networkPolicyProvisioning to Managed when proxy is set without the field
+      resourceName: cluster
+      initial: |
+        apiVersion: operator.openshift.io/v1alpha1
+        kind: ExternalSecretsConfig
+        spec:
+          appConfig:
+            proxy:
+              httpProxy: "http://proxy.example.com:3128"
+      expected: |
+        apiVersion: operator.openshift.io/v1alpha1
+        kind: ExternalSecretsConfig
+        spec:
+          appConfig:
+            logLevel: 1
+            proxy:
+              httpProxy: "http://proxy.example.com:3128"
+              networkPolicyProvisioning: Managed
+    - name: Should fail with invalid value for networkPolicyProvisioning
+      resourceName: cluster
+      initial: |
+        apiVersion: operator.openshift.io/v1alpha1
+        kind: ExternalSecretsConfig
+        spec:
+          appConfig:
+            proxy:
+              httpProxy: "http://proxy.example.com:3128"
+              networkPolicyProvisioning: Enabled
+      expectedError: "spec.appConfig.proxy.networkPolicyProvisioning: Unsupported value: \"Enabled\": supported values: \"Managed\", \"Unmanaged\""
+    - name: Should accept proxy config with all fields including networkPolicyProvisioning
+      resourceName: cluster
+      initial: |
+        apiVersion: operator.openshift.io/v1alpha1
+        kind: ExternalSecretsConfig
+        spec:
+          appConfig:
+            proxy:
+              httpProxy: "http://proxy.example.com:3128"
+              httpsProxy: "https://proxy.example.com:3129"
+              noProxy: "localhost,127.0.0.1,.cluster.local"
+              networkPolicyProvisioning: Unmanaged
+      expected: |
+        apiVersion: operator.openshift.io/v1alpha1
+        kind: ExternalSecretsConfig
+        spec:
+          appConfig:
+            logLevel: 1
+            proxy:
+              httpProxy: "http://proxy.example.com:3128"
+              httpsProxy: "https://proxy.example.com:3129"
+              noProxy: "localhost,127.0.0.1,.cluster.local"
+              networkPolicyProvisioning: Unmanaged
   onUpdate:
     - name: Should be able to update labels in controller config
       resourceName: cluster
@@ -1726,3 +1816,30 @@ tests:
                   - to:
                       - ipBlock:
                           cidr: 172.16.0.0/12
+    - name: Should be able to update networkPolicyProvisioning from Managed to Unmanaged
+      resourceName: cluster
+      initial: |
+        apiVersion: operator.openshift.io/v1alpha1
+        kind: ExternalSecretsConfig
+        spec:
+          appConfig:
+            proxy:
+              httpProxy: "http://proxy.example.com:3128"
+              networkPolicyProvisioning: Managed
+      updated: |
+        apiVersion: operator.openshift.io/v1alpha1
+        kind: ExternalSecretsConfig
+        spec:
+          appConfig:
+            proxy:
+              httpProxy: "http://proxy.example.com:3128"
+              networkPolicyProvisioning: Unmanaged
+      expected: |
+        apiVersion: operator.openshift.io/v1alpha1
+        kind: ExternalSecretsConfig
+        spec:
+          appConfig:
+            logLevel: 1
+            proxy:
+              httpProxy: "http://proxy.example.com:3128"
+              networkPolicyProvisioning: Unmanaged

--- a/api/v1alpha1/tests/externalsecretsmanager.operator.openshift.io/externalsecretsmanager.testsuite.yaml
+++ b/api/v1alpha1/tests/externalsecretsmanager.operator.openshift.io/externalsecretsmanager.testsuite.yaml
@@ -88,6 +88,7 @@ tests:
             proxy:
               httpProxy: "http://proxy.example.com:8080"
               httpsProxy: "https://proxy.example.com:8443"
+              networkPolicyProvisioning: Managed
               noProxy: "localhost,127.0.0.1,.local"
     - name: Should fail to create with invalid singleton name
       resourceName: invalid-name
@@ -182,6 +183,7 @@ tests:
             logLevel: 1
             proxy:
               httpProxy: "http://proxy-url-at-exactly-two-thousand-and-forty-eight-characters-to-test-the-boundary-condition-where-we-want-to-ensure-that-urls-at-the-maximum-allowed-length-are-accepted-properly-by-the-validation-system-while-urls-that-exceed-this-limit-are-rejected-appropriately-which-is-important-for-maintaining-proper-validation-boundaries-in-production-systems-where-configuration-parameters-must-be-validated-correctly-to-prevent-system-failures-or-unexpected-behavior-that-could-impact-application-functionality-and-user-experience-in-various-deployment-environments-including-development-staging-and-production-kubernetes-clusters-running-across-different-cloud-providers-and-on-premises-infrastructure-where-proxy-configurations-are-commonly-used-for-network-security-and-compliance-requirements-that-organizations-need-to-meet-for-their-business-operations-and-regulatory-obligations-in-different-geographical-regions-around-the-world-where-various-network-policies-and-security-measures-are-implemented-to-protect-sensitive-data-and-ensure-proper-access-control-for-applications-and-services-that-handle-confidential-information-and-business-critical-processes-that-must-operate-reliably-and-securely-at-all-times-without-interruption-or-performance-degradation-that-could-affect-end-users-and-customers-who-depend-on-these-systems-for-their-daily-activities-and-business-needs-which-makes-proper-validation-of-configuration-parameters-like-proxy-urls-essential-for-maintaining-system-stability-and-security-in-production-environments-where-any-configuration-error-could-have-significant-consequences-for-business-continuity-and-customer-satisfaction-which-is-why-we-implement-comprehensive-boundary-testing-to-ensure-that-all-validation-rules-work-correctly-at-their-specified-limits-and-provide-clear-error-messages-when-those-limits-are-exceeded-by-user-configurations.example.com:8080"
+              networkPolicyProvisioning: Managed
     - name: Should accept HTTPS proxy URL at maximum length boundary
       resourceName: cluster
       initial: |
@@ -200,6 +202,7 @@ tests:
             logLevel: 1
             proxy:
               httpsProxy: "https://secure-proxy-url-at-exactly-two-thousand-and-forty-eight-characters-to-test-the-boundary-condition-where-we-want-to-ensure-that-urls-at-the-maximum-allowed-length-are-accepted-properly-by-the-validation-system-while-urls-that-exceed-this-limit-are-rejected-appropriately-which-is-important-for-maintaining-proper-validation-boundaries-in-production-systems-where-configuration-parameters-must-be-validated-correctly-to-prevent-system-failures-or-unexpected-behavior-that-could-impact-application-functionality-and-user-experience-in-various-deployment-environments-including-development-staging-and-production-kubernetes-clusters-running-across-different-cloud-providers-and-on-premises-infrastructure-where-proxy-configurations-are-commonly-used-for-network-security-and-compliance-requirements-that-organizations-need-to-meet-for-their-business-operations-and-regulatory-obligations-in-different-geographical-regions-around-the-world-where-various-network-policies-and-security-measures-are-implemented-to-protect-sensitive-data-and-ensure-proper-access-control-for-applications-and-services-that-handle-confidential-information-and-business-critical-processes-that-must-operate-reliably-and-securely-at-all-times-without-interruption-or-performance-degradation-that-could-affect-end-users-and-customers-who-depend-on-these-systems-for-their-daily-activities-and-business-needs-which-makes-proper-validation-of-configuration-parameters-like-proxy-urls-essential-for-maintaining-system-stability-and-security-in-production-environments-where-any-configuration-error-could-have-significant-consequences-for-business-continuity-and-customer-satisfaction-which-is-why-we-implement-comprehensive-boundary-testing-to-ensure-that-all-validation-rules-work-correctly-at-their-specified-limits-and-provide-clear-error-messages-when-those-limits-are-exceeded.example.com:8443"
+              networkPolicyProvisioning: Managed
     - name: Should accept empty proxy configuration
       resourceName: cluster
       initial: |
@@ -220,6 +223,7 @@ tests:
             proxy:
               httpProxy: ""
               httpsProxy: ""
+              networkPolicyProvisioning: Managed
               noProxy: ""
   onUpdate:
     - name: Should be able to add global config after creation
@@ -337,6 +341,7 @@ tests:
             proxy:
               httpProxy: "http://proxy.company.com:3128"
               httpsProxy: "https://proxy.company.com:3128"
+              networkPolicyProvisioning: Managed
               noProxy: "localhost,127.0.0.1,.company.com"
     - name: Should be able to update node selector and tolerations
       resourceName: cluster

--- a/bundle/manifests/openshift-external-secrets-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/openshift-external-secrets-operator.clusterserviceversion.yaml
@@ -220,7 +220,7 @@ metadata:
     categories: Security
     console.openshift.io/disable-operand-delete: "true"
     containerImage: openshift.io/external-secrets-operator:latest
-    createdAt: "2026-03-06T13:50:37Z"
+    createdAt: "2026-05-18T08:51:19Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"

--- a/bundle/manifests/operator.openshift.io_externalsecretsconfigs.yaml
+++ b/bundle/manifests/operator.openshift.io_externalsecretsconfigs.yaml
@@ -1034,6 +1034,18 @@ spec:
                         maxLength: 2048
                         minLength: 0
                         type: string
+                      networkPolicyProvisioning:
+                        default: Managed
+                        description: |-
+                          NetworkPolicyProvisioning defines the management strategy for the proxy egress rule.
+                          When set to Managed, the operator automatically provisions and maintains
+                          a NetworkPolicy allowing traffic to the configured proxy.
+                          If no proxy is configured, no NetworkPolicy will be created
+                          regardless of this setting.
+                        enum:
+                        - Managed
+                        - Unmanaged
+                        type: string
                       noProxy:
                         description: |-
                           noProxy is a comma-separated list of hostnames and/or CIDRs and/or IPs for which the proxy should not be used.
@@ -1515,6 +1527,7 @@ spec:
 
                       Each entry allows specifying a name for the generated NetworkPolicy object,
                       along with its full Kubernetes NetworkPolicy definition.
+                      The operator prepends "eso-user-" to the provided name when creating the Kubernetes object.
 
                       If this field is not provided, external-secrets components will be isolated
                       with deny-all network policies, which will prevent proper operation.
@@ -1730,8 +1743,9 @@ spec:
                           x-kubernetes-list-type: atomic
                         name:
                           description: |-
-                            name is a unique identifier for this network policy configuration.
-                            This name will be used as part of the generated NetworkPolicy resource name.
+                            Name is the logical identifier for this network policy entry.
+                            The operator prepends "eso-user-" to this value when creating the Kubernetes
+                            NetworkPolicy object (e.g. "allow-egress" becomes "eso-user-allow-egress").
                           maxLength: 253
                           minLength: 1
                           type: string

--- a/bundle/manifests/operator.openshift.io_externalsecretsmanagers.yaml
+++ b/bundle/manifests/operator.openshift.io_externalsecretsmanagers.yaml
@@ -1031,6 +1031,18 @@ spec:
                         maxLength: 2048
                         minLength: 0
                         type: string
+                      networkPolicyProvisioning:
+                        default: Managed
+                        description: |-
+                          NetworkPolicyProvisioning defines the management strategy for the proxy egress rule.
+                          When set to Managed, the operator automatically provisions and maintains
+                          a NetworkPolicy allowing traffic to the configured proxy.
+                          If no proxy is configured, no NetworkPolicy will be created
+                          regardless of this setting.
+                        enum:
+                        - Managed
+                        - Unmanaged
+                        type: string
                       noProxy:
                         description: |-
                           noProxy is a comma-separated list of hostnames and/or CIDRs and/or IPs for which the proxy should not be used.

--- a/config/crd/bases/operator.openshift.io_externalsecretsconfigs.yaml
+++ b/config/crd/bases/operator.openshift.io_externalsecretsconfigs.yaml
@@ -1034,6 +1034,18 @@ spec:
                         maxLength: 2048
                         minLength: 0
                         type: string
+                      networkPolicyProvisioning:
+                        default: Managed
+                        description: |-
+                          NetworkPolicyProvisioning defines the management strategy for the proxy egress rule.
+                          When set to Managed, the operator automatically provisions and maintains
+                          a NetworkPolicy allowing traffic to the configured proxy.
+                          If no proxy is configured, no NetworkPolicy will be created
+                          regardless of this setting.
+                        enum:
+                        - Managed
+                        - Unmanaged
+                        type: string
                       noProxy:
                         description: |-
                           noProxy is a comma-separated list of hostnames and/or CIDRs and/or IPs for which the proxy should not be used.
@@ -1515,6 +1527,7 @@ spec:
 
                       Each entry allows specifying a name for the generated NetworkPolicy object,
                       along with its full Kubernetes NetworkPolicy definition.
+                      The operator prepends "eso-user-" to the provided name when creating the Kubernetes object.
 
                       If this field is not provided, external-secrets components will be isolated
                       with deny-all network policies, which will prevent proper operation.
@@ -1730,8 +1743,9 @@ spec:
                           x-kubernetes-list-type: atomic
                         name:
                           description: |-
-                            name is a unique identifier for this network policy configuration.
-                            This name will be used as part of the generated NetworkPolicy resource name.
+                            Name is the logical identifier for this network policy entry.
+                            The operator prepends "eso-user-" to this value when creating the Kubernetes
+                            NetworkPolicy object (e.g. "allow-egress" becomes "eso-user-allow-egress").
                           maxLength: 253
                           minLength: 1
                           type: string

--- a/config/crd/bases/operator.openshift.io_externalsecretsmanagers.yaml
+++ b/config/crd/bases/operator.openshift.io_externalsecretsmanagers.yaml
@@ -1031,6 +1031,18 @@ spec:
                         maxLength: 2048
                         minLength: 0
                         type: string
+                      networkPolicyProvisioning:
+                        default: Managed
+                        description: |-
+                          NetworkPolicyProvisioning defines the management strategy for the proxy egress rule.
+                          When set to Managed, the operator automatically provisions and maintains
+                          a NetworkPolicy allowing traffic to the configured proxy.
+                          If no proxy is configured, no NetworkPolicy will be created
+                          regardless of this setting.
+                        enum:
+                        - Managed
+                        - Unmanaged
+                        type: string
                       noProxy:
                         description: |-
                           noProxy is a comma-separated list of hostnames and/or CIDRs and/or IPs for which the proxy should not be used.

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -202,7 +202,7 @@ _Appears in:_
 | `certProvider` _[CertProvidersConfig](#certprovidersconfig)_ | certProvider is for defining the configuration for certificate providers used to manage TLS certificates for webhook and plugins. |  |  |
 | `labels` _object (keys:string, values:string)_ | labels to apply to all resources created for the external-secrets operand deployment.<br />This field can have a maximum of 20 entries. |  | MaxProperties: 20 <br />MinProperties: 0 <br /> |
 | `annotations` _object (keys:string, values:string)_ | annotations are for adding custom annotations to all the resources created for external-secrets deployment.<br />The annotations are merged with any default annotations set by the operator. User-specified annotations take precedence over defaults in case of conflicts.<br />Annotation keys containing domains `kubernetes.io/`, `openshift.io/`, `cert-manager.io/` or `k8s.io/` (including subdomains like `*.kubernetes.io/`) are not allowed. |  | MaxProperties: 20 <br />MinProperties: 0 <br /> |
-| `networkPolicies` _[NetworkPolicy](#networkpolicy) array_ | networkPolicies specifies the list of network policy configurations<br />to be applied to external-secrets pods.<br />Each entry allows specifying a name for the generated NetworkPolicy object,<br />along with its full Kubernetes NetworkPolicy definition.<br />If this field is not provided, external-secrets components will be isolated<br />with deny-all network policies, which will prevent proper operation. |  | MaxItems: 50 <br />MinItems: 0 <br /> |
+| `networkPolicies` _[NetworkPolicy](#networkpolicy) array_ | networkPolicies specifies the list of network policy configurations<br />to be applied to external-secrets pods.<br />Each entry allows specifying a name for the generated NetworkPolicy object,<br />along with its full Kubernetes NetworkPolicy definition.<br />The operator prepends "eso-user-" to the provided name when creating the Kubernetes object.<br />If this field is not provided, external-secrets components will be isolated<br />with deny-all network policies, which will prevent proper operation. |  | MaxItems: 50 <br />MinItems: 0 <br /> |
 | `componentConfigs` _[ComponentConfig](#componentconfig) array_ | componentConfigs allows specifying deployment-level configuration overrides for individual external-secrets components. This field enables fine-grained control over deployment settings for each component independently.<br />Each component can only have one configuration entry. |  | MaxItems: 4 <br />MinItems: 0 <br /> |
 
 
@@ -414,6 +414,23 @@ _Appears in:_
 | `labels` _object (keys:string, values:string)_ | labels to apply to all resources created by the operator.<br />This field can have a maximum of 20 entries. |  | MaxProperties: 20 <br />MinProperties: 0 <br /> |
 
 
+#### ManagementState
+
+_Underlying type:_ _string_
+
+ManagementState controls whether the operator manages the resource lifecycle.
+
+
+
+_Appears in:_
+- [ProxyConfig](#proxyconfig)
+
+| Field | Description |
+| --- | --- |
+| `Managed` | ManagementStateManaged indicates the Operator is responsible for the resource lifecycle.<br /> |
+| `Unmanaged` | ManagementStateUnmanaged indicates the User is responsible for the resource lifecycle.<br /> |
+
+
 #### Mode
 
 _Underlying type:_ _string_
@@ -446,7 +463,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `name` _string_ | name is a unique identifier for this network policy configuration.<br />This name will be used as part of the generated NetworkPolicy resource name. |  | MaxLength: 253 <br />MinLength: 1 <br /> |
+| `name` _string_ | Name is the logical identifier for this network policy entry.<br />The operator prepends "eso-user-" to this value when creating the Kubernetes<br />NetworkPolicy object (e.g. "allow-egress" becomes "eso-user-allow-egress"). |  | MaxLength: 253 <br />MinLength: 1 <br /> |
 | `componentName` _[ComponentName](#componentname)_ | componentName specifies which external-secrets component this network policy applies to. |  | Enum: [ExternalSecretsCoreController BitwardenSDKServer] <br /> |
 | `egress` _[NetworkPolicyEgressRule](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#networkpolicyegressrule-v1-networking) array_ | egress is a list of egress rules to be applied to the selected pods. Outgoing traffic<br />is allowed if there are no NetworkPolicies selecting the pod (and cluster policy<br />otherwise allows the traffic), OR if the traffic matches at least one egress rule<br />across all the NetworkPolicy objects whose podSelector matches the pod. If<br />this field is empty then this NetworkPolicy limits all outgoing traffic (and serves<br />solely to ensure that the pods it selects are isolated by default).<br />The operator will automatically handle ingress rules based on the current running ports. |  |  |
 
@@ -498,6 +515,7 @@ _Appears in:_
 | `httpProxy` _string_ | httpProxy is the URL of the proxy for HTTP requests.<br />This field can have a maximum of 2048 characters. |  | MaxLength: 2048 <br />MinLength: 0 <br /> |
 | `httpsProxy` _string_ | httpsProxy is the URL of the proxy for HTTPS requests.<br />This field can have a maximum of 2048 characters. |  | MaxLength: 2048 <br />MinLength: 0 <br /> |
 | `noProxy` _string_ | noProxy is a comma-separated list of hostnames and/or CIDRs and/or IPs for which the proxy should not be used.<br />This field can have a maximum of 4096 characters. |  | MaxLength: 4096 <br />MinLength: 0 <br /> |
+| `networkPolicyProvisioning` _[ManagementState](#managementstate)_ | NetworkPolicyProvisioning defines the management strategy for the proxy egress rule.<br />When set to Managed, the operator automatically provisions and maintains<br />a NetworkPolicy allowing traffic to the configured proxy.<br />If no proxy is configured, no NetworkPolicy will be created<br />regardless of this setting. | Managed | Enum: [Managed Unmanaged] <br /> |
 
 
 #### SecretReference

--- a/hack/govulncheck.sh
+++ b/hack/govulncheck.sh
@@ -24,7 +24,7 @@ set -o errexit
 ## Below vulnerabilities are in the go packages, which impacts the operator code and requires the fix to be available downstream.
 # - https://pkg.go.dev/vuln/GO-2026-4601 - Incorrect parsing of IPv6 host literals in net/url
 # - https://pkg.go.dev/vuln/GO-2026-4602 - FileInfo can escape from a Root in os
-KNOWN_VULNS_PATTERN="GO-2025-3521|GO-2025-3547|GO-2026-4601|GO-2026-4602"
+KNOWN_VULNS_PATTERN="GO-2025-3521|GO-2025-3547|GO-2026-4971|GO-2026-4918"
 
 GOVULNCHECK_BIN="${1:-}"
 OUTPUT_DIR="${2:-}"


### PR DESCRIPTION
[Ep Link ](https://github.com/openshift/enhancements/pull/1998)

Tested using custom workflow [workflow link](https://github.com/openshift-eng/oape-ai-e2e/pull/54) on ambient code platform.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `networkPolicyProvisioning` configuration field to proxy settings in both ExternalSecretsConfig and ExternalSecretsManager, allowing users to control automatic operator management of proxy egress NetworkPolicies (defaults to `Managed`; `Unmanaged` option available).

* **Tests**
  * Comprehensive test coverage for NetworkPolicy provisioning behavior, proxy port detection, and legacy policy cleanup during upgrades.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->