### PR TITLE
NO-JIRA: Add Console capability annotation to ConsoleYAMLSample resources

### DIFF
--- a/bundle/manifests/eso-external-secret-sample_console.openshift.io_v1_consoleyamlsample.yaml
+++ b/bundle/manifests/eso-external-secret-sample_console.openshift.io_v1_consoleyamlsample.yaml
@@ -1,6 +1,8 @@
 apiVersion: console.openshift.io/v1
 kind: ConsoleYAMLSample
 metadata:
+  annotations:
+    capability.openshift.io/name: Console
   name: eso-external-secret-sample
 spec:
   description: An example minimal ExternalSecret manifest

--- a/bundle/manifests/eso-vault-secret-store-provider-sample_console.openshift.io_v1_consoleyamlsample.yaml
+++ b/bundle/manifests/eso-vault-secret-store-provider-sample_console.openshift.io_v1_consoleyamlsample.yaml
@@ -1,6 +1,8 @@
 apiVersion: console.openshift.io/v1
 kind: ConsoleYAMLSample
 metadata:
+  annotations:
+    capability.openshift.io/name: Console
   name: eso-vault-secret-store-provider-sample
 spec:
   description: An example Vault SecretStore using Kubernetes Authentication method.

--- a/config/console/eso-external-secret-sample.yaml
+++ b/config/console/eso-external-secret-sample.yaml
@@ -2,6 +2,8 @@ apiVersion: console.openshift.io/v1
 kind: ConsoleYAMLSample
 metadata:
   name: eso-external-secret-sample
+  annotations:
+    capability.openshift.io/name: Console
 spec:
   targetResource:
     apiVersion: external-secrets.io/v1

--- a/config/console/eso-vault-secret-store-provider-sample.yaml
+++ b/config/console/eso-vault-secret-store-provider-sample.yaml
@@ -2,6 +2,8 @@ apiVersion: console.openshift.io/v1
 kind: ConsoleYAMLSample
 metadata:
   name: eso-vault-secret-store-provider-sample
+  annotations:
+    capability.openshift.io/name: Console
 spec:
   targetResource:
     apiVersion: external-secrets.io/v1


### PR DESCRIPTION
Add `capability.openshift.io/name: Console` annotation to the  ConsoleYAMLSample resources so OLM skips them on clusters where the Console capability is disabled.

Problem
On clusters without the Console capability (e.g., RAN RDS deployments), the cert-manager operator install fails with:

api-server resource not found installing ConsoleYAMLSample cert-manager-acme-issuer-sample:
GroupVersionKind console.openshift.io/v1, Kind=ConsoleYAMLSample not found on the cluster.

Fix
Add capability.openshift.io/name: Console annotation to `kind:ConsoleYAMLSample`
This tells OLM to skip these optional UI resources when Console is not available, allowing the operator to install successfully on Console-less clusters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ConsoleYAMLSample manifests with OpenShift console capability annotations across multiple configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->