### PR TITLE
ESO-448: Updates external-secrets to use v2.5.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ $(error IMG_VERSION '$(IMG_VERSION)' is not valid semver (expected: Major.Minor.
 endif
 
 # EXTERNAL_SECRETS_VERSION defines the external-secrets release version to fetch helm charts.
-EXTERNAL_SECRETS_VERSION ?= v2.6.0
+EXTERNAL_SECRETS_VERSION ?= v2.5.0
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/bindata/external-secrets/resources/certificate_external-secrets-webhook.yml
+++ b/bindata/external-secrets/resources/certificate_external-secrets-webhook.yml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets-webhook
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v2.6.0"
+    app.kubernetes.io/version: "v2.5.0"
     app.kubernetes.io/managed-by: external-secrets-operator
     external-secrets.io/component: webhook
 spec:

--- a/bindata/external-secrets/resources/clusterrole_external-secrets-cert-controller.yml
+++ b/bindata/external-secrets/resources/clusterrole_external-secrets-cert-controller.yml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets-cert-controller
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v2.6.0"
+    app.kubernetes.io/version: "v2.5.0"
     app.kubernetes.io/managed-by: external-secrets-operator
 rules:
   - apiGroups:

--- a/bindata/external-secrets/resources/clusterrole_external-secrets-controller.yml
+++ b/bindata/external-secrets/resources/clusterrole_external-secrets-controller.yml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v2.6.0"
+    app.kubernetes.io/version: "v2.5.0"
     app.kubernetes.io/managed-by: external-secrets-operator
 rules:
   - apiGroups:

--- a/bindata/external-secrets/resources/clusterrole_external-secrets-edit.yml
+++ b/bindata/external-secrets/resources/clusterrole_external-secrets-edit.yml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v2.6.0"
+    app.kubernetes.io/version: "v2.5.0"
     app.kubernetes.io/managed-by: external-secrets-operator
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"

--- a/bindata/external-secrets/resources/clusterrole_external-secrets-servicebindings.yml
+++ b/bindata/external-secrets/resources/clusterrole_external-secrets-servicebindings.yml
@@ -7,7 +7,7 @@ metadata:
     servicebinding.io/controller: "true"
     app.kubernetes.io/name: external-secrets
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v2.6.0"
+    app.kubernetes.io/version: "v2.5.0"
     app.kubernetes.io/managed-by: external-secrets-operator
 rules:
   - apiGroups:

--- a/bindata/external-secrets/resources/clusterrole_external-secrets-view.yml
+++ b/bindata/external-secrets/resources/clusterrole_external-secrets-view.yml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v2.6.0"
+    app.kubernetes.io/version: "v2.5.0"
     app.kubernetes.io/managed-by: external-secrets-operator
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"

--- a/bindata/external-secrets/resources/clusterrolebinding_external-secrets-cert-controller.yml
+++ b/bindata/external-secrets/resources/clusterrolebinding_external-secrets-cert-controller.yml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets-cert-controller
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v2.6.0"
+    app.kubernetes.io/version: "v2.5.0"
     app.kubernetes.io/managed-by: external-secrets-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/bindata/external-secrets/resources/clusterrolebinding_external-secrets-controller.yml
+++ b/bindata/external-secrets/resources/clusterrolebinding_external-secrets-controller.yml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v2.6.0"
+    app.kubernetes.io/version: "v2.5.0"
     app.kubernetes.io/managed-by: external-secrets-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/bindata/external-secrets/resources/deployment_external-secrets-cert-controller.yml
+++ b/bindata/external-secrets/resources/deployment_external-secrets-cert-controller.yml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets-cert-controller
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v2.6.0"
+    app.kubernetes.io/version: "v2.5.0"
     app.kubernetes.io/managed-by: external-secrets-operator
 spec:
   replicas: 1
@@ -21,7 +21,7 @@ spec:
       labels:
         app.kubernetes.io/name: external-secrets-cert-controller
         app.kubernetes.io/instance: external-secrets
-        app.kubernetes.io/version: "v2.6.0"
+        app.kubernetes.io/version: "v2.5.0"
         app.kubernetes.io/managed-by: external-secrets-operator
     spec:
       serviceAccountName: external-secrets-cert-controller
@@ -39,7 +39,7 @@ spec:
             runAsUser: 1000
             seccompProfile:
               type: RuntimeDefault
-          image: ghcr.io/external-secrets/external-secrets:v2.6.0
+          image: ghcr.io/external-secrets/external-secrets:v2.5.0
           imagePullPolicy: IfNotPresent
           args:
             - certcontroller

--- a/bindata/external-secrets/resources/deployment_external-secrets-webhook.yml
+++ b/bindata/external-secrets/resources/deployment_external-secrets-webhook.yml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets-webhook
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v2.6.0"
+    app.kubernetes.io/version: "v2.5.0"
     app.kubernetes.io/managed-by: external-secrets-operator
 spec:
   replicas: 1
@@ -21,7 +21,7 @@ spec:
       labels:
         app.kubernetes.io/name: external-secrets-webhook
         app.kubernetes.io/instance: external-secrets
-        app.kubernetes.io/version: "v2.6.0"
+        app.kubernetes.io/version: "v2.5.0"
         app.kubernetes.io/managed-by: external-secrets-operator
     spec:
       hostNetwork: false
@@ -39,7 +39,7 @@ spec:
             runAsUser: 1000
             seccompProfile:
               type: RuntimeDefault
-          image: ghcr.io/external-secrets/external-secrets:v2.6.0
+          image: ghcr.io/external-secrets/external-secrets:v2.5.0
           imagePullPolicy: IfNotPresent
           args:
             - webhook

--- a/bindata/external-secrets/resources/deployment_external-secrets.yml
+++ b/bindata/external-secrets/resources/deployment_external-secrets.yml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v2.6.0"
+    app.kubernetes.io/version: "v2.5.0"
     app.kubernetes.io/managed-by: external-secrets-operator
 spec:
   replicas: 1
@@ -21,7 +21,7 @@ spec:
       labels:
         app.kubernetes.io/name: external-secrets
         app.kubernetes.io/instance: external-secrets
-        app.kubernetes.io/version: "v2.6.0"
+        app.kubernetes.io/version: "v2.5.0"
         app.kubernetes.io/managed-by: external-secrets-operator
     spec:
       serviceAccountName: external-secrets
@@ -39,7 +39,7 @@ spec:
             runAsUser: 1000
             seccompProfile:
               type: RuntimeDefault
-          image: ghcr.io/external-secrets/external-secrets:v2.6.0
+          image: ghcr.io/external-secrets/external-secrets:v2.5.0
           imagePullPolicy: IfNotPresent
           args:
             - --concurrent=1

--- a/bindata/external-secrets/resources/role_external-secrets-leaderelection.yml
+++ b/bindata/external-secrets/resources/role_external-secrets-leaderelection.yml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v2.6.0"
+    app.kubernetes.io/version: "v2.5.0"
     app.kubernetes.io/managed-by: external-secrets-operator
 rules:
   - apiGroups:

--- a/bindata/external-secrets/resources/rolebinding_external-secrets-leaderelection.yml
+++ b/bindata/external-secrets/resources/rolebinding_external-secrets-leaderelection.yml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v2.6.0"
+    app.kubernetes.io/version: "v2.5.0"
     app.kubernetes.io/managed-by: external-secrets-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/bindata/external-secrets/resources/secret_external-secrets-webhook.yml
+++ b/bindata/external-secrets/resources/secret_external-secrets-webhook.yml
@@ -7,6 +7,6 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets-webhook
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v2.6.0"
+    app.kubernetes.io/version: "v2.5.0"
     app.kubernetes.io/managed-by: external-secrets-operator
     external-secrets.io/component: webhook

--- a/bindata/external-secrets/resources/service_external-secrets-cert-controller-metrics.yml
+++ b/bindata/external-secrets/resources/service_external-secrets-cert-controller-metrics.yml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets-cert-controller
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v2.6.0"
+    app.kubernetes.io/version: "v2.5.0"
     app.kubernetes.io/managed-by: external-secrets-operator
 spec:
   type: ClusterIP

--- a/bindata/external-secrets/resources/service_external-secrets-metrics.yml
+++ b/bindata/external-secrets/resources/service_external-secrets-metrics.yml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v2.6.0"
+    app.kubernetes.io/version: "v2.5.0"
     app.kubernetes.io/managed-by: external-secrets-operator
 spec:
   type: ClusterIP

--- a/bindata/external-secrets/resources/service_external-secrets-webhook.yml
+++ b/bindata/external-secrets/resources/service_external-secrets-webhook.yml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets-webhook
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v2.6.0"
+    app.kubernetes.io/version: "v2.5.0"
     app.kubernetes.io/managed-by: external-secrets-operator
     external-secrets.io/component: webhook
 spec:

--- a/bindata/external-secrets/resources/serviceaccount_external-secrets-cert-controller.yml
+++ b/bindata/external-secrets/resources/serviceaccount_external-secrets-cert-controller.yml
@@ -7,5 +7,5 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets-cert-controller
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v2.6.0"
+    app.kubernetes.io/version: "v2.5.0"
     app.kubernetes.io/managed-by: external-secrets-operator

--- a/bindata/external-secrets/resources/serviceaccount_external-secrets-webhook.yml
+++ b/bindata/external-secrets/resources/serviceaccount_external-secrets-webhook.yml
@@ -7,5 +7,5 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets-webhook
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v2.6.0"
+    app.kubernetes.io/version: "v2.5.0"
     app.kubernetes.io/managed-by: external-secrets-operator

--- a/bindata/external-secrets/resources/serviceaccount_external-secrets.yml
+++ b/bindata/external-secrets/resources/serviceaccount_external-secrets.yml
@@ -7,5 +7,5 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v2.6.0"
+    app.kubernetes.io/version: "v2.5.0"
     app.kubernetes.io/managed-by: external-secrets-operator

--- a/bindata/external-secrets/resources/validatingwebhookconfiguration_externalsecret-validate.yml
+++ b/bindata/external-secrets/resources/validatingwebhookconfiguration_externalsecret-validate.yml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets-webhook
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v2.6.0"
+    app.kubernetes.io/version: "v2.5.0"
     app.kubernetes.io/managed-by: external-secrets-operator
     external-secrets.io/component: webhook
 webhooks:

--- a/bindata/external-secrets/resources/validatingwebhookconfiguration_secretstore-validate.yml
+++ b/bindata/external-secrets/resources/validatingwebhookconfiguration_secretstore-validate.yml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets-webhook
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v2.6.0"
+    app.kubernetes.io/version: "v2.5.0"
     app.kubernetes.io/managed-by: external-secrets-operator
     external-secrets.io/component: webhook
 webhooks:

--- a/bundle/manifests/openshift-external-secrets-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/openshift-external-secrets-operator.clusterserviceversion.yaml
@@ -220,7 +220,7 @@ metadata:
     categories: Security
     console.openshift.io/disable-operand-delete: "true"
     containerImage: openshift.io/external-secrets-operator:latest
-    createdAt: "2026-06-18T12:03:02Z"
+    createdAt: "2026-06-19T12:17:03Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -745,9 +745,9 @@ spec:
                 - name: OPERATOR_IMAGE_VERSION
                   value: 1.2.0
                 - name: RELATED_IMAGE_EXTERNAL_SECRETS
-                  value: ghcr.io/external-secrets/external-secrets:v2.6.0
+                  value: ghcr.io/external-secrets/external-secrets:v2.5.0
                 - name: OPERAND_EXTERNAL_SECRETS_IMAGE_VERSION
-                  value: 2.6.0
+                  value: 2.5.0
                 - name: RELATED_IMAGE_BITWARDEN_SDK_SERVER
                   value: ghcr.io/external-secrets/bitwarden-sdk-server:v0.6.0
                 - name: BITWARDEN_SDK_SERVER_IMAGE_VERSION
@@ -840,7 +840,7 @@ spec:
   provider:
     name: Red Hat, Inc.
   relatedImages:
-  - image: ghcr.io/external-secrets/external-secrets:v2.6.0
+  - image: ghcr.io/external-secrets/external-secrets:v2.5.0
     name: external-secrets
   - image: ghcr.io/external-secrets/bitwarden-sdk-server:v0.6.0
     name: bitwarden-sdk-server

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -82,9 +82,9 @@ spec:
           - name: OPERATOR_IMAGE_VERSION
             value: 1.2.0
           - name: RELATED_IMAGE_EXTERNAL_SECRETS
-            value: ghcr.io/external-secrets/external-secrets:v2.6.0
+            value: ghcr.io/external-secrets/external-secrets:v2.5.0
           - name: OPERAND_EXTERNAL_SECRETS_IMAGE_VERSION
-            value: 2.6.0
+            value: 2.5.0
           - name: RELATED_IMAGE_BITWARDEN_SDK_SERVER
             value: ghcr.io/external-secrets/bitwarden-sdk-server:v0.6.0
           - name: BITWARDEN_SDK_SERVER_IMAGE_VERSION

--- a/images/ci/operand.Dockerfile
+++ b/images/ci/operand.Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-4.23 AS builder
 
-ARG RELEASE_BRANCH=v0.20.4
+ARG RELEASE_BRANCH=v2.5.0
 ARG GO_BUILD_TAGS=strictfipsruntime,openssl
 ARG SRC_DIR=/go/src/github.com/openshift/external-secrets
 

--- a/pkg/controller/common/utils_test.go
+++ b/pkg/controller/common/utils_test.go
@@ -551,7 +551,7 @@ func deploymentWithContainerEnv(env []corev1.EnvVar) appsv1.Deployment {
 					Containers: []corev1.Container{
 						{
 							Name:  "external-secrets",
-							Image: "ghcr.io/external-secrets/external-secrets:v2.6.0",
+							Image: "ghcr.io/external-secrets/external-secrets:v2.5.0",
 							Env:   env,
 						},
 					},
@@ -569,7 +569,7 @@ func deploymentWithContainerVolumeMounts(mounts []corev1.VolumeMount) appsv1.Dep
 					Containers: []corev1.Container{
 						{
 							Name:         "external-secrets",
-							Image:        "ghcr.io/external-secrets/external-secrets:v2.6.0",
+							Image:        "ghcr.io/external-secrets/external-secrets:v2.5.0",
 							VolumeMounts: mounts,
 						},
 					},

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -430,7 +430,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets-webhook
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v2.6.0"
+    app.kubernetes.io/version: "v2.5.0"
     app.kubernetes.io/managed-by: external-secrets-operator
     external-secrets.io/component: webhook
 spec:
@@ -470,7 +470,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets-cert-controller
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v2.6.0"
+    app.kubernetes.io/version: "v2.5.0"
     app.kubernetes.io/managed-by: external-secrets-operator
 rules:
   - apiGroups:
@@ -568,7 +568,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v2.6.0"
+    app.kubernetes.io/version: "v2.5.0"
     app.kubernetes.io/managed-by: external-secrets-operator
 rules:
   - apiGroups:
@@ -735,7 +735,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v2.6.0"
+    app.kubernetes.io/version: "v2.5.0"
     app.kubernetes.io/managed-by: external-secrets-operator
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
@@ -805,7 +805,7 @@ metadata:
     servicebinding.io/controller: "true"
     app.kubernetes.io/name: external-secrets
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v2.6.0"
+    app.kubernetes.io/version: "v2.5.0"
     app.kubernetes.io/managed-by: external-secrets-operator
 rules:
   - apiGroups:
@@ -842,7 +842,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v2.6.0"
+    app.kubernetes.io/version: "v2.5.0"
     app.kubernetes.io/managed-by: external-secrets-operator
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
@@ -908,7 +908,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets-cert-controller
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v2.6.0"
+    app.kubernetes.io/version: "v2.5.0"
     app.kubernetes.io/managed-by: external-secrets-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -943,7 +943,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v2.6.0"
+    app.kubernetes.io/version: "v2.5.0"
     app.kubernetes.io/managed-by: external-secrets-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1055,7 +1055,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets-cert-controller
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v2.6.0"
+    app.kubernetes.io/version: "v2.5.0"
     app.kubernetes.io/managed-by: external-secrets-operator
 spec:
   replicas: 1
@@ -1069,7 +1069,7 @@ spec:
       labels:
         app.kubernetes.io/name: external-secrets-cert-controller
         app.kubernetes.io/instance: external-secrets
-        app.kubernetes.io/version: "v2.6.0"
+        app.kubernetes.io/version: "v2.5.0"
         app.kubernetes.io/managed-by: external-secrets-operator
     spec:
       serviceAccountName: external-secrets-cert-controller
@@ -1087,7 +1087,7 @@ spec:
             runAsUser: 1000
             seccompProfile:
               type: RuntimeDefault
-          image: ghcr.io/external-secrets/external-secrets:v2.6.0
+          image: ghcr.io/external-secrets/external-secrets:v2.5.0
           imagePullPolicy: IfNotPresent
           args:
             - certcontroller
@@ -1143,7 +1143,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets-webhook
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v2.6.0"
+    app.kubernetes.io/version: "v2.5.0"
     app.kubernetes.io/managed-by: external-secrets-operator
 spec:
   replicas: 1
@@ -1157,7 +1157,7 @@ spec:
       labels:
         app.kubernetes.io/name: external-secrets-webhook
         app.kubernetes.io/instance: external-secrets
-        app.kubernetes.io/version: "v2.6.0"
+        app.kubernetes.io/version: "v2.5.0"
         app.kubernetes.io/managed-by: external-secrets-operator
     spec:
       hostNetwork: false
@@ -1175,7 +1175,7 @@ spec:
             runAsUser: 1000
             seccompProfile:
               type: RuntimeDefault
-          image: ghcr.io/external-secrets/external-secrets:v2.6.0
+          image: ghcr.io/external-secrets/external-secrets:v2.5.0
           imagePullPolicy: IfNotPresent
           args:
             - webhook
@@ -1240,7 +1240,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v2.6.0"
+    app.kubernetes.io/version: "v2.5.0"
     app.kubernetes.io/managed-by: external-secrets-operator
 spec:
   replicas: 1
@@ -1254,7 +1254,7 @@ spec:
       labels:
         app.kubernetes.io/name: external-secrets
         app.kubernetes.io/instance: external-secrets
-        app.kubernetes.io/version: "v2.6.0"
+        app.kubernetes.io/version: "v2.5.0"
         app.kubernetes.io/managed-by: external-secrets-operator
     spec:
       serviceAccountName: external-secrets
@@ -1272,7 +1272,7 @@ spec:
             runAsUser: 1000
             seccompProfile:
               type: RuntimeDefault
-          image: ghcr.io/external-secrets/external-secrets:v2.6.0
+          image: ghcr.io/external-secrets/external-secrets:v2.5.0
           imagePullPolicy: IfNotPresent
           args:
             - --concurrent=1
@@ -1314,7 +1314,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v2.6.0"
+    app.kubernetes.io/version: "v2.5.0"
     app.kubernetes.io/managed-by: external-secrets-operator
 rules:
   - apiGroups:
@@ -1368,7 +1368,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v2.6.0"
+    app.kubernetes.io/version: "v2.5.0"
     app.kubernetes.io/managed-by: external-secrets-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1404,7 +1404,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets-webhook
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v2.6.0"
+    app.kubernetes.io/version: "v2.5.0"
     app.kubernetes.io/managed-by: external-secrets-operator
     external-secrets.io/component: webhook
 `)
@@ -1470,7 +1470,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets-cert-controller
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v2.6.0"
+    app.kubernetes.io/version: "v2.5.0"
     app.kubernetes.io/managed-by: external-secrets-operator
 spec:
   type: ClusterIP
@@ -1508,7 +1508,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v2.6.0"
+    app.kubernetes.io/version: "v2.5.0"
     app.kubernetes.io/managed-by: external-secrets-operator
 spec:
   type: ClusterIP
@@ -1546,7 +1546,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets-webhook
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v2.6.0"
+    app.kubernetes.io/version: "v2.5.0"
     app.kubernetes.io/managed-by: external-secrets-operator
     external-secrets.io/component: webhook
 spec:
@@ -1617,7 +1617,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets-cert-controller
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v2.6.0"
+    app.kubernetes.io/version: "v2.5.0"
     app.kubernetes.io/managed-by: external-secrets-operator
 `)
 
@@ -1645,7 +1645,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets-webhook
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v2.6.0"
+    app.kubernetes.io/version: "v2.5.0"
     app.kubernetes.io/managed-by: external-secrets-operator
 `)
 
@@ -1673,7 +1673,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v2.6.0"
+    app.kubernetes.io/version: "v2.5.0"
     app.kubernetes.io/managed-by: external-secrets-operator
 `)
 
@@ -1700,7 +1700,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets-webhook
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v2.6.0"
+    app.kubernetes.io/version: "v2.5.0"
     app.kubernetes.io/managed-by: external-secrets-operator
     external-secrets.io/component: webhook
 webhooks:
@@ -1745,7 +1745,7 @@ metadata:
   labels:
     app.kubernetes.io/name: external-secrets-webhook
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v2.6.0"
+    app.kubernetes.io/version: "v2.5.0"
     app.kubernetes.io/managed-by: external-secrets-operator
     external-secrets.io/component: webhook
 webhooks:


### PR DESCRIPTION
external-secrets v2.6.0 requires go1.26.4, but the same is not available downstream, and hence using v2.5.0 release which requires go1.26.3, which is available downstream.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Downgraded external-secrets component from v2.6.0 to v2.5.0 across all Kubernetes resource manifests, container images, and related configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->