### PR TITLE
ESO-481: Fix secondary watch predicates to evaluate old and new objects on update

### DIFF
--- a/pkg/controller/external_secrets/controller.go
+++ b/pkg/controller/external_secrets/controller.go
@@ -40,7 +40,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -286,36 +285,12 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return []reconcile.Request{}
 	}
 
-	// On updates, check both old and new objects so that events where the managed
-	// label is removed externally still trigger reconciliation and label restoration.
-	isManagedResource := func(object client.Object) bool {
-		labels := object.GetLabels()
-		return labels != nil && labels[ManagedResourceLabelKey] == ManagedResourceLabelValue
-	}
-	managedResources := predicate.Funcs{
-		CreateFunc: func(e event.CreateEvent) bool {
-			return isManagedResource(e.Object)
-		},
-		UpdateFunc: func(e event.UpdateEvent) bool {
-			return isManagedResource(e.ObjectOld) || isManagedResource(e.ObjectNew)
-		},
-		DeleteFunc: func(e event.DeleteEvent) bool {
-			return isManagedResource(e.Object)
-		},
-		GenericFunc: func(e event.GenericEvent) bool {
-			return isManagedResource(e.Object)
-		},
-	}
+	// managedResources limits enqueues to operator-managed operand resources (app=external-secrets).
+	managedResources := labelMatchPredicate(isManagedResource)
 
-	// managedOrWatchedResources limits enqueues to operator-managed resources (app=external-secrets) and
-	// user referenced resources (like ConfigMaps) having the watch label (externalsecretsconfig.operator.openshift.io/watching)
-	// so unrelated resource changes do not trigger reconciliation.
-	managedOrWatchedResources := predicate.NewPredicateFuncs(func(object client.Object) bool {
-		if object.GetLabels() == nil {
-			return false
-		}
-		return hasManagedOrWatchLabel(object.GetLabels())
-	})
+	// managedOrWatchedResources also admits user referenced resources (like trustedCABundle
+	// ConfigMaps) labeled externalsecretsconfig.operator.openshift.io/watching.
+	managedOrWatchedResources := labelMatchPredicate(isManagedOrWatchedResource)
 
 	// Resources like Deployments are reconciled on spec generation or managed-label changes.
 	withIgnoreStatusUpdatePredicates := builder.WithPredicates(

--- a/pkg/controller/external_secrets/utils.go
+++ b/pkg/controller/external_secrets/utils.go
@@ -16,6 +16,8 @@ import (
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"go.uber.org/zap/zapcore"
 
@@ -262,8 +264,49 @@ func (r *Reconciler) isProxyEnabled() bool {
 // hasManagedOrWatchLabel reports whether labels identify an operand resource created
 // by the operator or a user configured resource that the operator watches.
 func hasManagedOrWatchLabel(labels map[string]string) bool {
+	if labels == nil {
+		return false
+	}
 	return labels[ManagedResourceLabelKey] == ManagedResourceLabelValue ||
 		labels[WatchedResourceLabelKey] == WatchedResourceLabelValue
+}
+
+// isManagedResource reports whether object is an operator-managed operand resource.
+func isManagedResource(object client.Object) bool {
+	if object == nil {
+		return false
+	}
+	labels := object.GetLabels()
+	return labels != nil && labels[ManagedResourceLabelKey] == ManagedResourceLabelValue
+}
+
+// isManagedOrWatchedResource reports whether object is an operator-managed operand or a
+// user-provided resource labeled for passive watch (e.g. trustedCABundle ConfigMaps).
+func isManagedOrWatchedResource(object client.Object) bool {
+	if object == nil {
+		return false
+	}
+	return hasManagedOrWatchLabel(object.GetLabels())
+}
+
+// labelMatchPredicate returns predicate.Funcs that admit events when match returns true for
+// the event object(s). On updates both old and new are checked so reconciliation still runs
+// when a matching label is removed externally.
+func labelMatchPredicate(match func(client.Object) bool) predicate.Funcs {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return match(e.Object)
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return match(e.ObjectOld) || match(e.ObjectNew)
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return match(e.Object)
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return match(e.Object)
+		},
+	}
 }
 
 // getWithCacheFallback reads a resource from the manager cache first. On IsNotFound it

--- a/pkg/controller/external_secrets/utils_test.go
+++ b/pkg/controller/external_secrets/utils_test.go
@@ -10,6 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	operatorv1alpha1 "github.com/openshift/external-secrets-operator/api/v1alpha1"
 	"github.com/openshift/external-secrets-operator/pkg/controller/client/fakes"
@@ -436,6 +437,72 @@ func TestUpdateWatchLabel(t *testing.T) {
 			}
 			if tt.wantPatch && !patched {
 				t.Fatal("expected Patch to be called")
+			}
+		})
+	}
+}
+
+func TestLabelMatchPredicateUpdate(t *testing.T) {
+	t.Parallel()
+
+	watchLabels := map[string]string{WatchedResourceLabelKey: WatchedResourceLabelValue}
+	managedLabels := map[string]string{ManagedResourceLabelKey: ManagedResourceLabelValue}
+
+	tests := []struct {
+		name      string
+		oldLabels map[string]string
+		newLabels map[string]string
+		want      bool
+	}{
+		{
+			name:      "both old and new watched",
+			oldLabels: watchLabels,
+			newLabels: watchLabels,
+			want:      true,
+		},
+		{
+			name:      "old watched only",
+			oldLabels: watchLabels,
+			newLabels: map[string]string{"foo": "bar"},
+			want:      true,
+		},
+		{
+			name:      "new watched only",
+			oldLabels: nil,
+			newLabels: watchLabels,
+			want:      true,
+		},
+		{
+			name:      "neither watched",
+			oldLabels: map[string]string{"foo": "bar"},
+			newLabels: map[string]string{"foo": "bar"},
+			want:      false,
+		},
+		{
+			name:      "managed label on old only",
+			oldLabels: managedLabels,
+			newLabels: map[string]string{"foo": "bar"},
+			want:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			updateEvent := event.UpdateEvent{
+				ObjectOld: &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Labels: tt.oldLabels}},
+				ObjectNew: &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Labels: tt.newLabels}},
+			}
+
+			gotManaged := labelMatchPredicate(isManagedResource).Update(updateEvent)
+			wantManaged := isManagedResource(updateEvent.ObjectOld) || isManagedResource(updateEvent.ObjectNew)
+			if gotManaged != wantManaged {
+				t.Fatalf("managed Update() = %v, want %v", gotManaged, wantManaged)
+			}
+
+			gotManagedOrWatched := labelMatchPredicate(isManagedOrWatchedResource).Update(updateEvent)
+			if gotManagedOrWatched != tt.want {
+				t.Fatalf("managedOrWatched Update() = %v, want %v", gotManagedOrWatched, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Fix the ConfigMap secondary watch predicate so update events are admitted when either the old or new object matches, not only `ObjectNew`
- Extract shared `labelMatchPredicate` helper and consolidate `isManagedResource` / `isManagedOrWatchedResource` label matchers
- Add unit tests covering update predicate behavior for both managed and watched resources

## Problem

Secondary watches use label predicates to decide which operand/user resources should enqueue `ExternalSecretsConfig` reconciliation.

`managedResources` already checked both `ObjectOld` and `ObjectNew` on updates, but `managedOrWatchedResources` (used for ConfigMaps, including user `trustedCABundle` references) was built with `predicate.NewPredicateFuncs`, which only inspects `ObjectNew`.

That meant updates where a watched label was present on the old object but removed on the new object could be filtered out before reconcile runs, breaking self-healing for watched ConfigMaps.

## Solution

- Introduce `labelMatchPredicate(match func(client.Object) bool)` with consistent Create/Update/Delete/Generic handling
- On updates, admit the event when `match(ObjectOld) || match(ObjectNew)`
- Use it for both:
  - `managedResources` (`app=external-secrets`)
  - `managedOrWatchedResources` (`app=external-secrets` or `externalsecretsconfig.operator.openshift.io/watching=true`)
- Move `isManagedResource` and `isManagedOrWatchedResource` into `utils.go` for reuse and testing

No change to composite predicate pairing:
- Deployments still use generation/label-change filtering + managed label match
- ConfigMaps still use `ResourceVersionChangedPredicate` + managed-or-watched label match

## Test plan

- [x] `go test ./pkg/controller/external_secrets/ -run TestLabelMatchPredicateUpdate`
- [x] `go test ./pkg/controller/external_secrets/ -run TestHasManagedOrWatchLabel`
- [x] Existing e2e trusted CA bundle recovery scenarios still pass (ConfigMap data fix while Degraded)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved controller event handling so changes to managed resources and watched resources are reliably detected.
  * Updates now trigger reconciliation even when labels are removed or restored, helping keep resource state in sync.
  * Nil or missing labels are handled more safely, reducing missed events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->