### PR TITLE
ESO-424: Restructures e2e test labeling, default filter, and prerequisite handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,8 +213,8 @@ test-unit: vet ## Run unit tests.
 # E2E_TIMEOUT is the timeout for e2e tests.
 E2E_TIMEOUT ?= 1h
 # E2E_GINKGO_LABEL_FILTER is ginkgo label query for selecting tests. See
-# https://onsi.github.io/ginkgo/#spec-labels. The default is to run tests on the AWS platform.
-E2E_GINKGO_LABEL_FILTER ?= "Platform: isSubsetOf {AWS}"
+# https://onsi.github.io/ginkgo/#spec-labels. Default runs Platform:AWS and Platform:Generic tests; excludes Feature:Proxy, Feature:Upgrade, and Provider:Bitwarden.
+E2E_GINKGO_LABEL_FILTER ?= Platform: isSubsetOf {AWS,Generic} && !(Feature: containsAny {Proxy, Upgrade}) && !(Provider: containsAny Bitwarden)
 .PHONY: test-e2e
 test-e2e: ## Run e2e tests against a cluster.
 	@echo "Running go e2e tests..."
@@ -225,7 +225,7 @@ test-e2e: ## Run e2e tests against a cluster.
 		-ginkgo.v \
 		-ginkgo.trace \
 		-ginkgo.show-node-events \
-		-ginkgo.label-filter=$(E2E_GINKGO_LABEL_FILTER)
+		-ginkgo.label-filter='$(E2E_GINKGO_LABEL_FILTER)'
 
 .PHONY: test-apis
 test-apis: $(ENVTEST) $(GINKGO) ## Run API integration tests.

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -1,146 +1,201 @@
-# E2E Test Suites
+# E2E test labels
 
-Run e2e tests from this repo’s root with `make test-e2e`. Use `E2E_GINKGO_LABEL_FILTER` to run a specific suite by label.
-
----
-
-## Running tests
-
-From the repo root:
+Run tests from the repo root:
 
 ```bash
-make test-e2e E2E_GINKGO_LABEL_FILTER="<label-filter>"
+make test-e2e E2E_GINKGO_LABEL_FILTER="<expression>"
 ```
 
-Default (if omitted): `E2E_GINKGO_LABEL_FILTER="Platform: isSubsetOf {AWS}"` (AWS-only).
-
-### Running the whole suite
-
-To run **all** e2e specs (every suite, regardless of label), pass an empty label filter:
+See [Ginkgo label filters](https://onsi.github.io/ginkgo/#spec-labels) for expression syntax. An empty filter runs every spec:
 
 ```bash
 make test-e2e E2E_GINKGO_LABEL_FILTER=""
 ```
 
-Ensure pre-requisites for each suite you care about are in place (see [Suites by label](#suites-by-label)). Suites whose pre-requisites are not met will skip (e.g. missing `bitwarden-creds` or `aws-creds`). To run only a subset of suites, use a label filter (see [Running multiple suites](#running-multiple-suites)).
+**No runtime skips.** If a spec is selected by the label filter, its prerequisites must be present or the spec **fails**. Use label filters to opt in to suites whose prerequisites you have configured.
 
-### Failure artifacts (debugging)
+## Label keys
 
-When a spec fails, the suite dumps logs and cluster state into **`<output-dir>/e2e-artifacts/failure-<timestamp>/`** so you can debug later. The output directory is **`ARTIFACT_DIR`** when set (e.g. in OpenShift CI); otherwise, when running locally via `make test-e2e`, it is **`_output`** at the repo root.
+| Key | Values | Meaning |
+|-----|--------|---------|
+| `Platform` | `AWS`, `GCP`, `Generic` | Cluster or portability requirement |
+| `Provider` | `AWS`, `Bitwarden` | External secret backend integration |
+| `API` | `Bitwarden` | Direct HTTP tests against bitwarden-sdk-server |
+| `Feature` | see below | Optional capability or functional area |
 
-Each failure dump includes:
+### Feature values
 
-- **`pods/`** – Last 500 lines of logs per pod and `describe` (YAML) for operator, operand, and test namespaces.
-- **`events/`** – Recent events per namespace.
-- **`resources/`** – ExternalSecretsConfig (cluster), ClusterSecretStores, ExternalSecrets, and PushSecrets (YAML).
+| Value | Test area |
+|-------|-----------|
+| `OverrideEnv` | Custom env vars on operand deployments |
+| `RevisionHistoryLimit` | Deployment revision history limits |
+| `UnsafeAllowGenericTargets` | ExternalSecretsManager feature gate propagation |
+| `CustomAnnotations` | Annotation apply/remove and managed-annotation restoration |
+| `CustomLabels` | Custom and managed label lifecycle |
+| `NetworkPolicy` | Static and custom network policy naming |
+| `Proxy` | Proxy egress network policy (requires cluster-wide OpenShift proxy) |
+| `TrustedCABundle` | trustedCABundle ConfigMap mounting and validation |
+| `Upgrade` | Post-upgrade migration checks (temporary) |
 
-JUnit and JSON reports are also written to the same output directory (see root README Testing section).
+## Default filter
 
----
+`make test-e2e` uses:
 
-## Suites by label
-
-### Platform:AWS (AWS Secret Manager)
-
-| Item | Details |
-|------|--------|
-| **Label filter** | `"Platform: isSubsetOf {AWS}"` (default) |
-| **Pre-requisites** | Cluster on AWS (e.g. OpenShift on AWS); K8s secret `aws-creds` in namespace `kube-system` with keys `aws_access_key_id` and `aws_secret_access_key` (credentials for AWS Secrets Manager in `ap-south-1`). On OpenShift on AWS this secret is typically made available in `kube-system` by the platform. |
-| **Make command** | `make test-e2e` or `make test-e2e E2E_GINKGO_LABEL_FILTER="Platform: isSubsetOf {AWS}"` |
-
----
-
-### Provider:Bitwarden (ESO CR–based Bitwarden)
-
-When this suite runs, it **enables Bitwarden in ExternalSecretsConfig** and **creates the TLS secret** (certificate for bitwarden-sdk-server) in the operand namespace. The default e2e cluster CR does not enable Bitwarden; enabling and the TLS secret are done only when tests with the Bitwarden label run. See `config/crd/bases/operator.openshift.io_externalsecretsconfigs.yaml` for `plugins.bitwardenSecretManagerProvider` (mode, secretRef).
-
-| Item | Details |
-|------|--------|
-| **Label filter** | `"Provider:Bitwarden"` |
-| **Pre-requisites** | ESO installed. Create the Bitwarden credentials secret **`bitwarden-creds`** in **`external-secrets-operator`** (see [Creating the Bitwarden credentials secret](#creating-the-bitwarden-credentials-secret)). The suite enables the plugin and creates the TLS secret. Optional env: `BITWARDEN_SDK_SERVER_URL` (default: `https://bitwarden-sdk-server.external-secrets.svc.cluster.local:9998`). |
-| **Make command** | `make test-e2e E2E_GINKGO_LABEL_FILTER="Provider:Bitwarden"` |
-
----
-
-### API:Bitwarden (Direct HTTP to bitwarden-sdk-server)
-
-| Item | Details |
-|------|--------|
-| **Label filter** | `"API:Bitwarden"` |
-| **Pre-requisites** | bitwarden-sdk-server reachable (e.g. in-cluster). For Secrets API tests: create the Bitwarden credentials secret **`bitwarden-creds`** in **`external-secrets-operator`** (see [Creating the Bitwarden credentials secret](#creating-the-bitwarden-credentials-secret)). Optional env: `BITWARDEN_SDK_SERVER_URL` (default: `https://bitwarden-sdk-server.external-secrets.svc.cluster.local:9998`). |
-| **Make command** | `make test-e2e E2E_GINKGO_LABEL_FILTER="API:Bitwarden"` |
-
-#### Creating the Bitwarden credentials secret
-
-The Provider:Bitwarden and API:Bitwarden suites expect the secret to be named **`bitwarden-creds`** in namespace **`external-secrets-operator`**. The secret must have keys **`token`** (Bitwarden machine account access token), **`organization_id`**, and **`project_id`**.
-
-**From literal values:**
-
-```bash
-kubectl create secret generic bitwarden-creds \
-  --namespace=external-secrets-operator \
-  --from-literal=token="YOUR_BITWARDEN_ACCESS_TOKEN" \
-  --from-literal=organization_id="YOUR_ORGANIZATION_ID" \
-  --from-literal=project_id="YOUR_PROJECT_ID"
+```
+Platform: isSubsetOf {AWS,Generic} && !(Feature: containsAny {Proxy, Upgrade}) && !(Provider: containsAny Bitwarden)
 ```
 
-**From env vars (avoids secrets in shell history):**
+This runs portable tests plus AWS provider tests, and **API:Bitwarden** health/auth (bitwarden-sdk-server is deployed automatically — no pre-provisioned secrets). Excludes `Feature:Proxy`, `Feature:Upgrade`, and all `Provider:Bitwarden` specs (including Bitwarden provider sync and API Secrets API).
+
+## Prerequisites
+
+### Secrets you provision
 
 ```bash
-export BITWARDEN_ACCESS_TOKEN="..."
-export BITWARDEN_ORGANIZATION_ID="..."
-export BITWARDEN_PROJECT_ID="..."
-kubectl create secret generic bitwarden-creds \
-  --namespace=external-secrets-operator \
-  --from-literal=token="${BITWARDEN_ACCESS_TOKEN}" \
-  --from-literal=organization_id="${BITWARDEN_ORGANIZATION_ID}" \
-  --from-literal=project_id="${BITWARDEN_PROJECT_ID}"
+hack/e2e-setup-secrets.sh setup
 ```
 
----
+| Secret | Namespace | Keys | Required when filter includes |
+|--------|-----------|------|-------------------------------|
+| `aws-creds` | `kube-system` | `aws_access_key_id`, `aws_secret_access_key` | `Provider:AWS` (`Platform:AWS` or `Platform:GCP`) |
+| `bitwarden-creds` | `external-secrets-operator` | `token`, `organization_id`, `project_id` | `Provider:Bitwarden` |
 
-### CrossPlatform:GCP-AWS (GCP cluster, AWS Secrets Manager)
+### Secrets created by tests
 
-Cluster runs on **GCP**; the test uses a **ClusterSecretStore** backed by **AWS Secrets Manager**. You must create a Kubernetes secret that holds AWS credentials in a **fixed** name and namespace (see below).
+| Secret | Namespace | Keys | Created by |
+|--------|-----------|------|------------|
+| `bitwarden-tls-certs` | `external-secrets` | `tls.crt`, `tls.key`, `ca.crt` | `API:Bitwarden` and `Provider:Bitwarden` via `ensureBitwardenOperandReady` |
 
-| Item | Details |
-|------|--------|
-| **Label filter** | `"CrossPlatform:GCP-AWS"` |
-| **Pre-requisites** | Cluster on GCP (or any non-AWS cluster). Create the AWS credentials secret with **name** `aws-creds` in **namespace** `kube-system` (see below). |
-| **Make command** | `make test-e2e E2E_GINKGO_LABEL_FILTER="CrossPlatform:GCP-AWS"` |
+The bitwarden-sdk-server plugin uses **`bitwarden-tls-certs`** (TLS materials for the in-cluster SDK server). That is separate from **`bitwarden-creds`**, which holds a live Bitwarden Secrets Manager API token for provider sync and Secrets API tests.
 
-#### Creating the AWS credentials secret
+### Other environment requirements
 
-The test expects the secret to be named **`aws-creds`** in namespace **`kube-system`**. The secret must have keys **`aws_access_key_id`** and **`aws_secret_access_key`**. The test uses AWS region `ap-south-1`.
+| Requirement | Required when filter includes |
+|-------------|-------------------------------|
+| Cluster-wide OpenShift proxy (`proxy.config.openshift.io/cluster`) | `Feature:Proxy` |
 
-**From literal values:**
+If a prerequisite is missing, the affected spec **fails** with a message pointing here — it does not skip.
+
+## Filter recipes
+
+| Filter | What runs |
+|--------|-----------|
+| *(default, omitted)* | `Platform:AWS` + `Platform:Generic` except `Feature:Proxy`, `Feature:Upgrade`, `Provider:Bitwarden`; includes `API:Bitwarden` health/auth |
+| `""` | Entire suite |
+| `Platform:AWS` | AWS Secret Manager sync, push, and refresh |
+| `Platform:GCP && Provider:AWS` | GCP cluster using AWS Secrets Manager |
+| `Provider:AWS` | Any AWS Secrets Manager integration (`Platform:AWS` or `Platform:GCP`) |
+| `Provider:Bitwarden` | Bitwarden provider sync and API Secrets API |
+| `API:Bitwarden` | bitwarden-sdk-server HTTP API (deploys plugin + `bitwarden-tls-certs` automatically) |
+| `API:Bitwarden \|\| Provider:Bitwarden` | All Bitwarden HTTP and provider tests (requires `bitwarden-creds` for Secrets API / provider sync) |
+| `Feature:TrustedCABundle` | Trusted CA bundle suite |
+| `Feature:Proxy` | Proxy egress network policy |
+| `Feature:Upgrade` | Post-upgrade network policy migration check |
+| `Feature:NetworkPolicy` | Static and custom network policy naming |
+| `Feature:OverrideEnv` | Component override env vars |
+| `Feature:RevisionHistoryLimit` | Revision history limit defaults and overrides |
+| `Feature:UnsafeAllowGenericTargets` | UnsafeAllowGenericTargets feature propagation |
+| `Feature:CustomAnnotations` | Annotation lifecycle tests |
+| `Feature:CustomLabels` | Label lifecycle tests |
+| `Platform: isSubsetOf {GCP,Generic} && !(Feature: containsAny {Proxy, Upgrade}) && !(Provider: containsAny Bitwarden)` | Portable + GCP/AWS cross-platform tests on a GCP cluster |
+
+### Combining labels
 
 ```bash
-kubectl create secret generic aws-creds \
-  --namespace=kube-system \
-  --from-literal=aws_access_key_id="YOUR_AWS_ACCESS_KEY_ID" \
-  --from-literal=aws_secret_access_key="YOUR_AWS_SECRET_ACCESS_KEY"
-```
-
-**From env vars (avoids secrets in shell history):**
-
-```bash
-export AWS_ACCESS_KEY_ID="..."
-export AWS_SECRET_ACCESS_KEY="..."
-kubectl create secret generic aws-creds \
-  --namespace=kube-system \
-  --from-literal=aws_access_key_id="${AWS_ACCESS_KEY_ID}" \
-  --from-literal=aws_secret_access_key="${AWS_SECRET_ACCESS_KEY}"
-```
-
----
-
-## Running multiple suites
-
-To run more than one label (e.g. Bitwarden provider and API):
-
-```bash
+# Bitwarden provider and API together (requires bitwarden-creds)
 make test-e2e E2E_GINKGO_LABEL_FILTER="Provider:Bitwarden || API:Bitwarden"
+
+# All network-policy-related tests
+make test-e2e E2E_GINKGO_LABEL_FILTER="Feature:NetworkPolicy || Feature:Proxy"
+
+# AWS integration only (any platform label that uses AWS SM)
+make test-e2e E2E_GINKGO_LABEL_FILTER="Provider:AWS"
 ```
 
-See [Ginkgo label documentation](https://onsi.github.io/ginkgo/#spec-labels) for label query syntax.
+## Specs by label
+
+### `Platform:AWS` + `Provider:AWS`
+
+File: `e2e_test.go` — **AWS Secret Manager**
+
+- ClusterSecretStore, ExternalSecret sync, PushSecret, secret refresh
+- Requires `aws-creds` in `kube-system`
+
+### `Platform:GCP` + `Provider:AWS`
+
+File: `e2e_test.go` — **Cross-platform: GCP cluster and AWS Secrets Manager**
+
+- Same AWS SM flows on a non-AWS cluster
+- Requires `aws-creds` in `kube-system`
+
+### `Platform:Generic` feature specs
+
+File: `e2e_test.go`
+
+| Feature | Context |
+|---------|---------|
+| `OverrideEnv` | Environment Variables |
+| `RevisionHistoryLimit` | Deployment Revision History Limit |
+| `UnsafeAllowGenericTargets` | UnsafeAllowGenericTargets feature |
+| `CustomAnnotations` | Annotations; Managed Annotation Restoration |
+| `CustomLabels` | Custom Labels; Managed Label Restoration |
+| `NetworkPolicy` | Static Network Policy Naming; Custom Network Policy Naming |
+| `NetworkPolicy` + `Upgrade` | Post-upgrade skip-np-cleanup-check annotation (also tagged `Feature:Upgrade`) |
+| `Proxy` | Proxy Egress Network Policy |
+
+File: `trusted_ca_bundle_test.go`
+
+| Feature | Describe |
+|---------|----------|
+| `TrustedCABundle` | Trusted CA Bundle |
+
+The **Custom Network Policy Naming** spec adds a dummy egress port to `ExternalSecretsConfig` (if not already present — entries cannot be removed due to CEL immutability), verifies the operator creates `eso-user-e2e-test-custom-np` in the operand namespace (`external-secrets`), and leaves the CR entry in place.
+
+### `Provider:Bitwarden`
+
+File: `bitwarden_es_test.go` — **Bitwarden Provider**
+
+- Creates `bitwarden-tls-certs`, enables Bitwarden plugin on ExternalSecretsConfig, runs PushSecret/ExternalSecret flows
+- Requires `bitwarden-creds` in `external-secrets-operator`
+
+File: `bitwarden_api_test.go` — **Secrets API** context (also labeled `Provider:Bitwarden`)
+
+- Live Bitwarden cloud API CRUD via bitwarden-sdk-server
+- Requires `bitwarden-creds`
+
+### `API:Bitwarden`
+
+File: `bitwarden_api_test.go` — **Bitwarden SDK Server API**
+
+- **BeforeAll:** generates TLS materials, creates `bitwarden-tls-certs` in `external-secrets`, enables `plugins.bitwardenSecretManagerProvider.secretRef`, waits for bitwarden-sdk-server
+- **Health / Auth:** no `bitwarden-creds` required
+- **Secrets API:** labeled `Provider:Bitwarden`; requires `bitwarden-creds` (excluded from default filter)
+
+## Test output and failure artifacts
+
+Ginkgo JUnit and JSON reports are always written under the output directory:
+
+| Environment | Output directory |
+|-------------|------------------|
+| OpenShift CI | `$ARTIFACT_DIR` (set by CI) |
+| Local (`make test-e2e` from repo root) | `_output/` at the repo root |
+
+Files written on every run:
+
+- `_output/e2e-junit.xml`
+- `_output/e2e-report.json`
+
+When a spec in the main e2e describe fails, a snapshot is also written to:
+
+```
+_output/e2e-artifacts/failure-<timestamp>/
+├── pods/       # last 500 log lines and describe YAML per pod (operator, operand, test namespaces)
+├── events/     # recent events per namespace
+└── resources/  # ExternalSecretsConfig, ClusterSecretStores, ExternalSecrets, PushSecrets (YAML)
+```
+
+Override the base directory by setting `ARTIFACT_DIR` before running tests:
+
+```bash
+ARTIFACT_DIR=/tmp/eso-e2e make test-e2e
+```

--- a/test/e2e/bitwarden_api_test.go
+++ b/test/e2e/bitwarden_api_test.go
@@ -41,7 +41,7 @@ const (
 // inClusterBaseURL is the Bitwarden SDK server URL as seen from inside the cluster (same as external-secrets controller). Respects BITWARDEN_SDK_SERVER_URL.
 var inClusterBaseURL = utils.GetBitwardenSDKServerURL()
 
-var _ = Describe("Bitwarden SDK Server API", Ordered, Label("API:Bitwarden", "Suite:Bitwarden"), func() {
+var _ = Describe("Bitwarden SDK Server API", Ordered, Label("Platform:Generic", "API:Bitwarden"), func() {
 	var (
 		ctx       context.Context
 		clientset *kubernetes.Clientset
@@ -50,28 +50,17 @@ var _ = Describe("Bitwarden SDK Server API", Ordered, Label("API:Bitwarden", "Su
 
 	BeforeAll(func() {
 		ctx = context.Background()
-		var err error
 		clientset = suiteClientset
 		Expect(clientset).NotTo(BeNil(), "suite clientset not initialized")
 
-		By("Ensuring Bitwarden operand is ready (enable plugin, wait for server)")
-		Expect(ensureBitwardenOperandReady(ctx)).To(Succeed())
+		By("Provisioning bitwarden-tls-certs, enabling the plugin secretRef, and waiting for bitwarden-sdk-server")
+		Expect(ensureBitwardenOperandReady(ctx, nil)).To(Succeed())
 
-		credNamespace := utils.BitwardenCredSecretNamespace
-		_, err = clientset.CoreV1().Secrets(credNamespace).Get(ctx, utils.BitwardenCredSecretName, metav1.GetOptions{})
-		if err != nil {
-			Skip(fmt.Sprintf("Bitwarden credentials secret %s/%s required for API tests. See docs/e2e/README.md. Error: %v", credNamespace, utils.BitwardenCredSecretName, err))
-		}
-
-		// Run API test Jobs in the operand namespace (external-secrets) so they can reach bitwarden-sdk-server
-		// (same network as the controller). Copy the cred secret there so the Job can mount it.
 		namespace = utils.BitwardenOperandNamespace
-		By("Copying Bitwarden cred secret to " + namespace + " for API test Jobs")
-		Expect(utils.CopySecretToNamespace(ctx, clientset, utils.BitwardenCredSecretName, credNamespace, utils.BitwardenCredSecretName, namespace)).To(Succeed())
 	})
 
-	runAPIJob := func(jobName, script string) (int, string) {
-		code, logs, err := utils.RunBitwardenAPIJob(ctx, clientset, namespace, jobName, []string{"sh", "-c", script}, apiJobTimeout)
+	runCurlJob := func(jobName, script string) (int, string) {
+		code, logs, err := utils.RunBitwardenCurlJob(ctx, clientset, namespace, jobName, []string{"sh", "-c", script}, apiJobTimeout)
 		Expect(err).NotTo(HaveOccurred(), "job %s: %s", jobName, logs)
 		return code, logs
 	}
@@ -79,13 +68,13 @@ var _ = Describe("Bitwarden SDK Server API", Ordered, Label("API:Bitwarden", "Su
 	Context("Health", func() {
 		It("GET /ready should return 200 with body ready", func() {
 			script := fmt.Sprintf("code=$(curl -k -s -o /tmp/out -w '%%{http_code}' %s/ready) && body=$(cat /tmp/out) && [ \"$code\" = \"200\" ] && [ \"$body\" = \"ready\" ] || (echo \"code=$code body=$body\"; exit 1)", inClusterBaseURL)
-			code, logs := runAPIJob("api-ready-"+utils.GetRandomString(5), script)
+			code, logs := runCurlJob("api-ready-"+utils.GetRandomString(5), script)
 			Expect(code).To(Equal(0), "expected exit 0: %s", logs)
 		})
 
 		It("GET /live should return 200 with body live", func() {
 			script := fmt.Sprintf("code=$(curl -k -s -o /tmp/out -w '%%{http_code}' %s/live) && body=$(cat /tmp/out) && [ \"$code\" = \"200\" ] && [ \"$body\" = \"live\" ] || (echo \"code=$code body=$body\"; exit 1)", inClusterBaseURL)
-			code, logs := runAPIJob("api-live-"+utils.GetRandomString(5), script)
+			code, logs := runCurlJob("api-live-"+utils.GetRandomString(5), script)
 			Expect(code).To(Equal(0), "expected exit 0: %s", logs)
 		})
 	})
@@ -93,18 +82,35 @@ var _ = Describe("Bitwarden SDK Server API", Ordered, Label("API:Bitwarden", "Su
 	Context("Auth", func() {
 		It("request without Warden-Access-Token should return 401", func() {
 			script := fmt.Sprintf("code=$(curl -k -s -o /dev/null -w '%%{http_code}' -X GET -H 'Content-Type: application/json' -d '{\"organizationId\":\"00000000-0000-0000-0000-000000000000\"}' %s%s/secrets) && [ \"$code\" = \"401\" ] || (echo \"code=$code\"; exit 1)", inClusterBaseURL, apiPath)
-			code, logs := runAPIJob("api-auth-no-token-"+utils.GetRandomString(5), script)
+			code, logs := runCurlJob("api-auth-no-token-"+utils.GetRandomString(5), script)
 			Expect(code).To(Equal(0), "expected exit 0: %s", logs)
 		})
 
 		It("request with invalid token should return 400", func() {
 			script := fmt.Sprintf("code=$(curl -k -s -o /dev/null -w '%%{http_code}' -X GET -H 'Content-Type: application/json' -H 'Warden-Access-Token: invalid-token' -d '{\"organizationId\":\"00000000-0000-0000-0000-000000000000\"}' %s%s/secrets) && [ \"$code\" = \"400\" ] || (echo \"code=$code\"; exit 1)", inClusterBaseURL, apiPath)
-			code, logs := runAPIJob("api-auth-invalid-token-"+utils.GetRandomString(5), script)
+			code, logs := runCurlJob("api-auth-invalid-token-"+utils.GetRandomString(5), script)
 			Expect(code).To(Equal(0), "expected exit 0: %s", logs)
 		})
 	})
 
-	Context("Secrets API", func() {
+	Context("Secrets API", Label("Provider:Bitwarden"), func() {
+		BeforeAll(func() {
+			credNamespace := utils.BitwardenCredSecretNamespace
+			_, err := clientset.CoreV1().Secrets(credNamespace).Get(ctx, utils.BitwardenCredSecretName, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred(),
+				"Bitwarden credentials secret %s/%s required for Secrets API tests (keys: token, organization_id, project_id). See test/e2e/README.md",
+				credNamespace, utils.BitwardenCredSecretName)
+
+			By("Copying Bitwarden cred secret to " + namespace + " for API test Jobs")
+			Expect(utils.CopySecretToNamespace(ctx, clientset, utils.BitwardenCredSecretName, credNamespace, utils.BitwardenCredSecretName, namespace)).To(Succeed())
+		})
+
+		runAPIJob := func(jobName, script string) (int, string) {
+			code, logs, err := utils.RunBitwardenAPIJob(ctx, clientset, namespace, jobName, []string{"sh", "-c", script}, apiJobTimeout)
+			Expect(err).NotTo(HaveOccurred(), "job %s: %s", jobName, logs)
+			return code, logs
+		}
+
 		It("GET /rest/api/1/secrets (ListSecrets) should return 200 with data array", func() {
 			credPath := utils.BitwardenCredMountPath()
 			script := fmt.Sprintf("TOKEN=$(cat %s/token) && ORG=$(cat %s/organization_id) && code=$(curl -k -s -o /tmp/out -w '%%{http_code}' -X GET -H 'Content-Type: application/json' -H \"Warden-Access-Token: $TOKEN\" -d \"{\\\"organizationId\\\":\\\"$ORG\\\"}\" %s%s/secrets) && [ \"$code\" = \"200\" ] && grep -q '\"data\"' /tmp/out || (echo \"code=$code\"; cat /tmp/out; exit 1)", credPath, credPath, inClusterBaseURL, apiPath)
@@ -114,8 +120,6 @@ var _ = Describe("Bitwarden SDK Server API", Ordered, Label("API:Bitwarden", "Su
 
 		It("POST /rest/api/1/secret (CreateSecret) then GET and DELETE", func() {
 			credPath := utils.BitwardenCredMountPath()
-			// Create, extract id, Get, Update, Delete; each step must succeed (exit 0).
-			// Bitwarden Secrets Manager requires projectIds when creating a secret.
 			script := fmt.Sprintf(`
 TOKEN=$(cat %s/token) && ORG=$(cat %s/organization_id) && PROJECT=$(cat %s/project_id) && BASE=%s
 BODY="{\"key\":\"e2e-api-crud\",\"value\":\"v1\",\"note\":\"e2e\",\"organizationId\":\"$ORG\",\"projectIds\":[\"$PROJECT\"]}"

--- a/test/e2e/bitwarden_es_test.go
+++ b/test/e2e/bitwarden_es_test.go
@@ -20,7 +20,6 @@ limitations under the License.
 package e2e
 
 import (
-	"bytes"
 	"context"
 	"encoding/base64"
 	"fmt"
@@ -28,15 +27,10 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	networkingv1 "k8s.io/api/networking/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/runtime/serializer/yaml"
-	intstr "k8s.io/apimachinery/pkg/util/intstr"
-	yamlutil "k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
@@ -47,114 +41,18 @@ import (
 
 	operatorv1alpha1 "github.com/openshift/external-secrets-operator/api/v1alpha1"
 	"github.com/openshift/external-secrets-operator/pkg/controller/common"
-	externalsecrets "github.com/openshift/external-secrets-operator/pkg/controller/external_secrets"
 	"github.com/openshift/external-secrets-operator/test/utils"
 )
 
 const (
-	bitwardenTLSSecretName            = "bitwarden-tls-certs"
-	bitwardenSDKServerPodPrefix       = "bitwarden-sdk-server"
 	bitwardenPushSecretResourceName   = "bitwarden-push-secret"
 	bitwardenExternalSecretByNameName = "bitwarden-external-secret-by-name"
 	bitwardenExternalSecretByUUIDName = "bitwarden-external-secret"
-	bitwardenEgressNetworkPolicyName  = "allow-egress-to-bitwarden-sdk-server"
 	// bitwardenResourceWaitTimeout allows for slow first requests and provider retries to the SDK server.
 	bitwardenResourceWaitTimeout = 4 * time.Minute
 )
 
-// ensureBitwardenOperandReady ensures the cluster has ExternalSecretsConfig with Bitwarden enabled and
-// bitwarden-sdk-server is running and reachable. It is used by the API:Bitwarden suite when run standalone
-// (without Provider:Bitwarden) so that GET /ready can succeed. Uses package-level cfg and suite clients.
-func ensureBitwardenOperandReady(ctx context.Context) error {
-	clientset := suiteClientset
-	dynamicClient := suiteDynamicClient
-	runtimeClient := suiteRuntimeClient
-	if clientset == nil || dynamicClient == nil || runtimeClient == nil {
-		return fmt.Errorf("suite clients not initialized (run full suite or ensure BeforeSuite ran)")
-	}
-
-	tlsMaterials, err := utils.GenerateSelfSignedCertForBitwardenServer()
-	if err != nil {
-		return err
-	}
-
-	esc := &operatorv1alpha1.ExternalSecretsConfig{}
-	if err := runtimeClient.Get(ctx, client.ObjectKey{Name: common.ExternalSecretsConfigObjectName}, esc); err != nil {
-		if k8serrors.IsNotFound(err) {
-			createESC, err := loadExternalSecretsConfigFromFileWithBitwardenNetworkPolicy(testassets.ReadFile, externalSecretsFile)
-			if err != nil {
-				return err
-			}
-			if err := runtimeClient.Create(ctx, createESC); err != nil {
-				return err
-			}
-			if err := utils.WaitForExternalSecretsConfigReady(ctx, dynamicClient, common.ExternalSecretsConfigObjectName, 2*time.Minute); err != nil {
-				return err
-			}
-		} else {
-			return err
-		}
-	} else {
-		if _, err := ensureBitwardenEgressOnExternalSecretsConfig(ctx, runtimeClient); err != nil {
-			return err
-		}
-		if err := utils.WaitForExternalSecretsConfigReady(ctx, dynamicClient, common.ExternalSecretsConfigObjectName, 2*time.Minute); err != nil {
-			return err
-		}
-	}
-
-	_, err = clientset.CoreV1().Namespaces().Get(ctx, utils.BitwardenOperandNamespace, metav1.GetOptions{})
-	if err != nil && k8serrors.IsNotFound(err) {
-		operandNS := &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:   utils.BitwardenOperandNamespace,
-				Labels: map[string]string{"app": "external-secrets"},
-			},
-		}
-		if _, err := clientset.CoreV1().Namespaces().Create(ctx, operandNS, metav1.CreateOptions{}); err != nil {
-			return err
-		}
-	} else if err != nil {
-		return err
-	}
-
-	_ = clientset.CoreV1().Secrets(utils.BitwardenOperandNamespace).Delete(ctx, bitwardenTLSSecretName, metav1.DeleteOptions{})
-	if err := utils.CreateBitwardenTLSSecret(ctx, clientset, utils.BitwardenOperandNamespace, bitwardenTLSSecretName, tlsMaterials); err != nil {
-		return err
-	}
-
-	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		esc := &operatorv1alpha1.ExternalSecretsConfig{}
-		if err := runtimeClient.Get(ctx, client.ObjectKey{Name: common.ExternalSecretsConfigObjectName}, esc); err != nil {
-			return err
-		}
-		if esc.Spec.Plugins.BitwardenSecretManagerProvider == nil {
-			esc.Spec.Plugins.BitwardenSecretManagerProvider = &operatorv1alpha1.BitwardenSecretManagerProvider{}
-		}
-		esc.Spec.Plugins.BitwardenSecretManagerProvider.Mode = operatorv1alpha1.Enabled
-		esc.Spec.Plugins.BitwardenSecretManagerProvider.SecretRef = &operatorv1alpha1.SecretReference{Name: bitwardenTLSSecretName}
-		return runtimeClient.Update(ctx, esc)
-	})
-	if err != nil {
-		return err
-	}
-
-	if err := utils.RestartBitwardenSDKServerPods(ctx, clientset); err != nil {
-		return err
-	}
-	if err := utils.VerifyPodsReadyByPrefix(ctx, clientset, utils.BitwardenOperandNamespace, []string{bitwardenSDKServerPodPrefix}); err != nil {
-		return err
-	}
-	if err := utils.VerifyPodsReadyByPrefix(ctx, clientset, utils.BitwardenOperandNamespace, []string{externalsecrets.OperandWebhookPodPrefix}); err != nil {
-		return err
-	}
-	if err := utils.WaitForBitwardenSDKServerReachableFromCluster(ctx, clientset, 90*time.Second); err != nil {
-		return err
-	}
-	return nil
-}
-
-var _ = Describe("Bitwarden Provider", Ordered, Label("Provider:Bitwarden", "Suite:Bitwarden"), func() {
+var _ = Describe("Bitwarden Provider", Ordered, Label("Platform:Generic", "Provider:Bitwarden"), func() {
 	ctx := context.Background()
 	var (
 		clientset          *kubernetes.Clientset
@@ -182,9 +80,15 @@ var _ = Describe("Bitwarden Provider", Ordered, Label("Provider:Bitwarden", "Sui
 		runtimeClient = suiteRuntimeClient
 
 		token, orgID, projectID, err := utils.FetchBitwardenCredsFromSecret(ctx, clientset, utils.BitwardenCredSecretName, utils.BitwardenCredSecretNamespace)
-		if err != nil || token == "" || orgID == "" || projectID == "" {
-			Skip(fmt.Sprintf("Bitwarden credentials secret %s/%s required (keys: token, organization_id, project_id). See docs/e2e/README.md. Error: %v", utils.BitwardenCredSecretNamespace, utils.BitwardenCredSecretName, err))
-		}
+		Expect(err).NotTo(HaveOccurred(),
+			"Bitwarden credentials secret %s/%s required (keys: token, organization_id, project_id). See test/e2e/README.md",
+			utils.BitwardenCredSecretNamespace, utils.BitwardenCredSecretName)
+		Expect(token).NotTo(BeEmpty(), "Bitwarden credentials secret %s/%s must contain a non-empty token",
+			utils.BitwardenCredSecretNamespace, utils.BitwardenCredSecretName)
+		Expect(orgID).NotTo(BeEmpty(), "Bitwarden credentials secret %s/%s must contain organization_id",
+			utils.BitwardenCredSecretNamespace, utils.BitwardenCredSecretName)
+		Expect(projectID).NotTo(BeEmpty(), "Bitwarden credentials secret %s/%s must contain project_id",
+			utils.BitwardenCredSecretNamespace, utils.BitwardenCredSecretName)
 		bitwardenOrgID = orgID
 		bitwardenProjectID = projectID
 
@@ -192,73 +96,13 @@ var _ = Describe("Bitwarden Provider", Ordered, Label("Provider:Bitwarden", "Sui
 		tlsMaterials, err = utils.GenerateSelfSignedCertForBitwardenServer()
 		Expect(err).NotTo(HaveOccurred())
 
-		// Ensure cluster ExternalSecretsConfig exists first so the operator creates the operand namespace (external-secrets).
-		// When this suite runs before the main e2e Describe, create from testdata (with Bitwarden egress network policy) and wait for Ready.
 		esc := &operatorv1alpha1.ExternalSecretsConfig{}
-		if err := runtimeClient.Get(ctx, client.ObjectKey{Name: common.ExternalSecretsConfigObjectName}, esc); err != nil {
-			if k8serrors.IsNotFound(err) {
-				By("Creating cluster ExternalSecretsConfig from testdata with Bitwarden egress network policy")
-				createESC, err := loadExternalSecretsConfigFromFileWithBitwardenNetworkPolicy(testassets.ReadFile, externalSecretsFile)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(runtimeClient.Create(ctx, createESC)).To(Succeed())
-				By("Waiting for ExternalSecretsConfig to be Ready")
-				Expect(utils.WaitForExternalSecretsConfigReady(ctx, dynamicClient, common.ExternalSecretsConfigObjectName, 2*time.Minute)).To(Succeed())
-			} else {
-				Expect(err).NotTo(HaveOccurred())
-			}
-		} else {
-			By("Ensuring ExternalSecretsConfig has Bitwarden egress network policy (required for controller to reach bitwarden-sdk-server)")
-			updated, err := ensureBitwardenEgressOnExternalSecretsConfig(ctx, runtimeClient)
-			Expect(err).NotTo(HaveOccurred())
-			if updated {
-				By("Waiting for ExternalSecretsConfig to be Ready after adding Bitwarden egress policy")
-			} else {
-				By("Waiting for ExternalSecretsConfig to be Ready (cluster CR already exists)")
-			}
-			Expect(utils.WaitForExternalSecretsConfigReady(ctx, dynamicClient, common.ExternalSecretsConfigObjectName, 2*time.Minute)).To(Succeed())
-		}
-
-		// Ensure operand namespace exists: create it if missing (e.g. deleted by a previous AfterSuite).
-		By("Ensuring operand namespace " + utils.BitwardenOperandNamespace + " exists")
-		_, err = clientset.CoreV1().Namespaces().Get(ctx, utils.BitwardenOperandNamespace, metav1.GetOptions{})
-		if err != nil && k8serrors.IsNotFound(err) {
-			operandNS := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:   utils.BitwardenOperandNamespace,
-					Labels: map[string]string{"app": "external-secrets"},
-				},
-			}
-			_, err = clientset.CoreV1().Namespaces().Create(ctx, operandNS, metav1.CreateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-		} else if err != nil {
-			Expect(err).NotTo(HaveOccurred())
-		}
-
-		// Per CRD: when bitwardenSecretManagerProvider.mode is Enabled, secretRef or certManager must be set.
-		// secretRef names the TLS secret (tls.crt, tls.key, ca.crt) for bitwarden-sdk-server in the operand namespace.
-		By("Creating TLS secret in " + utils.BitwardenOperandNamespace + " namespace")
-		_ = clientset.CoreV1().Secrets(utils.BitwardenOperandNamespace).Delete(ctx, bitwardenTLSSecretName, metav1.DeleteOptions{})
-		err = utils.CreateBitwardenTLSSecret(ctx, clientset, utils.BitwardenOperandNamespace, bitwardenTLSSecretName, tlsMaterials)
-		Expect(err).NotTo(HaveOccurred())
-
-		By("Enabling Bitwarden in ExternalSecretsConfig with secretRef")
-		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			esc := &operatorv1alpha1.ExternalSecretsConfig{}
-			if err := runtimeClient.Get(ctx, client.ObjectKey{Name: common.ExternalSecretsConfigObjectName}, esc); err != nil {
-				return err
-			}
+		if err := runtimeClient.Get(ctx, client.ObjectKey{Name: common.ExternalSecretsConfigObjectName}, esc); err == nil {
 			originalESC = esc.DeepCopy()
-			if esc.Spec.Plugins.BitwardenSecretManagerProvider == nil {
-				esc.Spec.Plugins.BitwardenSecretManagerProvider = &operatorv1alpha1.BitwardenSecretManagerProvider{}
-			}
-			esc.Spec.Plugins.BitwardenSecretManagerProvider.Mode = operatorv1alpha1.Enabled
-			esc.Spec.Plugins.BitwardenSecretManagerProvider.SecretRef = &operatorv1alpha1.SecretReference{Name: bitwardenTLSSecretName}
-			return runtimeClient.Update(ctx, esc)
-		})
-		Expect(err).NotTo(HaveOccurred())
+		}
 
-		By("Restarting bitwarden-sdk-server pods so they load the new TLS secret")
-		Expect(utils.RestartBitwardenSDKServerPods(ctx, clientset)).To(Succeed())
+		By("Enabling Bitwarden plugin and waiting for bitwarden-sdk-server")
+		Expect(ensureBitwardenOperandReady(ctx, tlsMaterials)).To(Succeed())
 
 		By("Creating test namespace")
 		ns := &corev1.Namespace{
@@ -270,20 +114,6 @@ var _ = Describe("Bitwarden Provider", Ordered, Label("Provider:Bitwarden", "Sui
 		created, err := clientset.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		testNamespace = created.Name
-
-		By("Waiting for bitwarden-sdk-server pod to be ready")
-		Expect(utils.VerifyPodsReadyByPrefix(ctx, clientset, utils.BitwardenOperandNamespace, []string{
-			bitwardenSDKServerPodPrefix,
-		})).To(Succeed())
-
-		By("Waiting for external-secrets webhook pod to be ready (required for ClusterSecretStore validation)")
-		Expect(utils.VerifyPodsReadyByPrefix(ctx, clientset, utils.BitwardenOperandNamespace, []string{
-			externalsecrets.OperandWebhookPodPrefix,
-		})).To(Succeed())
-
-		By("Verifying bitwarden-sdk-server is reachable from cluster (same network as controller)")
-		Expect(utils.WaitForBitwardenSDKServerReachableFromCluster(ctx, clientset, 90*time.Second)).To(Succeed(),
-			"bitwarden-sdk-server must be reachable at https://%s:%s/ready from within the cluster; check pod logs and TLS", utils.BitwardenSDKServerFQDN, utils.BitwardenSDKServerPort)
 
 		clusterStoreName = fmt.Sprintf("bitwarden-store-%s", utils.GetRandomString(5))
 
@@ -439,77 +269,3 @@ var _ = Describe("Bitwarden Provider", Ordered, Label("Provider:Bitwarden", "Sui
 		}, time.Minute, 10*time.Second).Should(Succeed())
 	})
 })
-
-// loadExternalSecretsConfigFromFileWithBitwardenNetworkPolicy loads the cluster ExternalSecretsConfig from the
-// given file and appends the network policy that allows the main controller to reach bitwarden-sdk-server on port 9998.
-// This is used when the Bitwarden e2e creates the CR (CR does not exist yet). networkPolicies are immutable, so the
-// policy must be set at create time.
-func loadExternalSecretsConfigFromFileWithBitwardenNetworkPolicy(assetFunc func(string) ([]byte, error), filename string) (*operatorv1alpha1.ExternalSecretsConfig, error) {
-	data, err := assetFunc(filename)
-	if err != nil {
-		return nil, err
-	}
-	decoder := yamlutil.NewYAMLOrJSONDecoder(bytes.NewReader(data), 1024)
-	var rawObj runtime.RawExtension
-	if err := decoder.Decode(&rawObj); err != nil {
-		return nil, err
-	}
-	obj, _, err := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme).Decode(rawObj.Raw, nil, nil)
-	if err != nil {
-		return nil, err
-	}
-	unstructuredMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
-	if err != nil {
-		return nil, err
-	}
-	esc := &operatorv1alpha1.ExternalSecretsConfig{}
-	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredMap, esc); err != nil {
-		return nil, err
-	}
-	esc.Spec.ControllerConfig.NetworkPolicies = append(esc.Spec.ControllerConfig.NetworkPolicies, bitwardenEgressNetworkPolicy())
-	return esc, nil
-}
-
-// bitwardenEgressNetworkPolicy returns the NetworkPolicy that allows the core controller to reach bitwarden-sdk-server:9998.
-func bitwardenEgressNetworkPolicy() operatorv1alpha1.NetworkPolicy {
-	port9998 := intstr.FromInt32(9998)
-	tcp := corev1.ProtocolTCP
-	return operatorv1alpha1.NetworkPolicy{
-		Name:          bitwardenEgressNetworkPolicyName,
-		ComponentName: operatorv1alpha1.CoreController,
-		Egress: []networkingv1.NetworkPolicyEgressRule{
-			{
-				To: []networkingv1.NetworkPolicyPeer{
-					{PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app.kubernetes.io/name": "bitwarden-sdk-server"}}},
-				},
-				Ports: []networkingv1.NetworkPolicyPort{
-					{Protocol: &tcp, Port: &port9998},
-				},
-			},
-		},
-	}
-}
-
-// ensureBitwardenEgressOnExternalSecretsConfig ensures the cluster ExternalSecretsConfig has the Bitwarden egress
-// network policy. If the policy is missing, it is appended and the CR is updated. Returns true if an update was made.
-func ensureBitwardenEgressOnExternalSecretsConfig(ctx context.Context, c client.Client) (bool, error) {
-	var updated bool
-	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		esc := &operatorv1alpha1.ExternalSecretsConfig{}
-		if err := c.Get(ctx, client.ObjectKey{Name: common.ExternalSecretsConfigObjectName}, esc); err != nil {
-			return err
-		}
-		for _, np := range esc.Spec.ControllerConfig.NetworkPolicies {
-			if np.Name == bitwardenEgressNetworkPolicyName {
-				return nil
-			}
-		}
-		esc.Spec.ControllerConfig.NetworkPolicies = append(esc.Spec.ControllerConfig.NetworkPolicies, bitwardenEgressNetworkPolicy())
-		if err := c.Update(ctx, esc); err != nil {
-			return err
-		}
-		updated = true
-		return nil
-	})
-	return updated, err
-}

--- a/test/e2e/bitwarden_helpers_test.go
+++ b/test/e2e/bitwarden_helpers_test.go
@@ -1,0 +1,213 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer/yaml"
+	intstr "k8s.io/apimachinery/pkg/util/intstr"
+	yamlutil "k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	operatorv1alpha1 "github.com/openshift/external-secrets-operator/api/v1alpha1"
+	"github.com/openshift/external-secrets-operator/pkg/controller/common"
+	externalsecrets "github.com/openshift/external-secrets-operator/pkg/controller/external_secrets"
+	"github.com/openshift/external-secrets-operator/test/utils"
+)
+
+const (
+	bitwardenSDKServerPodPrefix      = "bitwarden-sdk-server"
+	bitwardenEgressNetworkPolicyName = "allow-egress-to-bitwarden-sdk-server"
+)
+
+// ensureBitwardenOperandReady enables the Bitwarden plugin on ExternalSecretsConfig,
+// creates bitwarden-tls-certs (tls.crt, tls.key, ca.crt) in the operand namespace, sets secretRef,
+// and waits for bitwarden-sdk-server to be reachable. Does not use bitwarden-creds (live cloud API token).
+func ensureBitwardenOperandReady(ctx context.Context, tlsMaterials *utils.BitwardenTLSMaterials) error {
+	clientset := suiteClientset
+	dynamicClient := suiteDynamicClient
+	runtimeClient := suiteRuntimeClient
+	if clientset == nil || dynamicClient == nil || runtimeClient == nil {
+		return fmt.Errorf("suite clients not initialized (run full suite or ensure BeforeSuite ran)")
+	}
+
+	var err error
+	if tlsMaterials == nil {
+		tlsMaterials, err = utils.GenerateSelfSignedCertForBitwardenServer()
+		if err != nil {
+			return err
+		}
+	}
+
+	esc := &operatorv1alpha1.ExternalSecretsConfig{}
+	if err := runtimeClient.Get(ctx, client.ObjectKey{Name: common.ExternalSecretsConfigObjectName}, esc); err != nil {
+		if k8serrors.IsNotFound(err) {
+			createESC, err := loadExternalSecretsConfigFromFileWithBitwardenNetworkPolicy(testassets.ReadFile, externalSecretsFile)
+			if err != nil {
+				return err
+			}
+			if err := runtimeClient.Create(ctx, createESC); err != nil {
+				return err
+			}
+			if err := utils.WaitForExternalSecretsConfigReady(ctx, dynamicClient, common.ExternalSecretsConfigObjectName, 2*time.Minute); err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	} else {
+		if _, err := ensureBitwardenEgressOnExternalSecretsConfig(ctx, runtimeClient); err != nil {
+			return err
+		}
+		if err := utils.WaitForExternalSecretsConfigReady(ctx, dynamicClient, common.ExternalSecretsConfigObjectName, 2*time.Minute); err != nil {
+			return err
+		}
+	}
+
+	_, err = clientset.CoreV1().Namespaces().Get(ctx, utils.BitwardenOperandNamespace, metav1.GetOptions{})
+	if err != nil && k8serrors.IsNotFound(err) {
+		operandNS := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   utils.BitwardenOperandNamespace,
+				Labels: map[string]string{"app": "external-secrets"},
+			},
+		}
+		if _, err := clientset.CoreV1().Namespaces().Create(ctx, operandNS, metav1.CreateOptions{}); err != nil {
+			return err
+		}
+	} else if err != nil {
+		return err
+	}
+
+	_ = clientset.CoreV1().Secrets(utils.BitwardenOperandNamespace).Delete(ctx, utils.BitwardenTLSSecretName, metav1.DeleteOptions{})
+	if err := utils.CreateBitwardenTLSSecret(ctx, clientset, utils.BitwardenOperandNamespace, utils.BitwardenTLSSecretName, tlsMaterials); err != nil {
+		return err
+	}
+
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		esc := &operatorv1alpha1.ExternalSecretsConfig{}
+		if err := runtimeClient.Get(ctx, client.ObjectKey{Name: common.ExternalSecretsConfigObjectName}, esc); err != nil {
+			return err
+		}
+		if esc.Spec.Plugins.BitwardenSecretManagerProvider == nil {
+			esc.Spec.Plugins.BitwardenSecretManagerProvider = &operatorv1alpha1.BitwardenSecretManagerProvider{}
+		}
+		esc.Spec.Plugins.BitwardenSecretManagerProvider.Mode = operatorv1alpha1.Enabled
+		esc.Spec.Plugins.BitwardenSecretManagerProvider.SecretRef = &operatorv1alpha1.SecretReference{Name: utils.BitwardenTLSSecretName}
+		return runtimeClient.Update(ctx, esc)
+	})
+	if err != nil {
+		return err
+	}
+
+	if err := utils.RestartBitwardenSDKServerPods(ctx, clientset); err != nil {
+		return err
+	}
+	if err := utils.VerifyPodsReadyByPrefix(ctx, clientset, utils.BitwardenOperandNamespace, []string{bitwardenSDKServerPodPrefix}); err != nil {
+		return err
+	}
+	if err := utils.VerifyPodsReadyByPrefix(ctx, clientset, utils.BitwardenOperandNamespace, []string{externalsecrets.OperandWebhookPodPrefix}); err != nil {
+		return err
+	}
+	if err := utils.WaitForBitwardenSDKServerReachableFromCluster(ctx, clientset, 90*time.Second); err != nil {
+		return err
+	}
+	return nil
+}
+
+// loadExternalSecretsConfigFromFileWithBitwardenNetworkPolicy loads the cluster ExternalSecretsConfig from the
+// given file and appends the network policy that allows the main controller to reach bitwarden-sdk-server on port 9998.
+func loadExternalSecretsConfigFromFileWithBitwardenNetworkPolicy(assetFunc func(string) ([]byte, error), filename string) (*operatorv1alpha1.ExternalSecretsConfig, error) {
+	data, err := assetFunc(filename)
+	if err != nil {
+		return nil, err
+	}
+	decoder := yamlutil.NewYAMLOrJSONDecoder(bytes.NewReader(data), 1024)
+	var rawObj runtime.RawExtension
+	if err := decoder.Decode(&rawObj); err != nil {
+		return nil, err
+	}
+	obj, _, err := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme).Decode(rawObj.Raw, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	unstructuredMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		return nil, err
+	}
+	esc := &operatorv1alpha1.ExternalSecretsConfig{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredMap, esc); err != nil {
+		return nil, err
+	}
+	esc.Spec.ControllerConfig.NetworkPolicies = append(esc.Spec.ControllerConfig.NetworkPolicies, bitwardenEgressNetworkPolicy())
+	return esc, nil
+}
+
+func bitwardenEgressNetworkPolicy() operatorv1alpha1.NetworkPolicy {
+	port9998 := intstr.FromInt32(9998)
+	tcp := corev1.ProtocolTCP
+	return operatorv1alpha1.NetworkPolicy{
+		Name:          bitwardenEgressNetworkPolicyName,
+		ComponentName: operatorv1alpha1.CoreController,
+		Egress: []networkingv1.NetworkPolicyEgressRule{
+			{
+				To: []networkingv1.NetworkPolicyPeer{
+					{PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app.kubernetes.io/name": "bitwarden-sdk-server"}}},
+				},
+				Ports: []networkingv1.NetworkPolicyPort{
+					{Protocol: &tcp, Port: &port9998},
+				},
+			},
+		},
+	}
+}
+
+func ensureBitwardenEgressOnExternalSecretsConfig(ctx context.Context, c client.Client) (bool, error) {
+	var updated bool
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		esc := &operatorv1alpha1.ExternalSecretsConfig{}
+		if err := c.Get(ctx, client.ObjectKey{Name: common.ExternalSecretsConfigObjectName}, esc); err != nil {
+			return err
+		}
+		for _, np := range esc.Spec.ControllerConfig.NetworkPolicies {
+			if np.Name == bitwardenEgressNetworkPolicyName {
+				return nil
+			}
+		}
+		esc.Spec.ControllerConfig.NetworkPolicies = append(esc.Spec.ControllerConfig.NetworkPolicies, bitwardenEgressNetworkPolicy())
+		if err := c.Update(ctx, esc); err != nil {
+			return err
+		}
+		updated = true
+		return nil
+	})
+	return updated, err
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -47,8 +47,8 @@ import (
 	. "github.com/onsi/gomega"
 
 	operatorv1alpha1 "github.com/openshift/external-secrets-operator/api/v1alpha1"
-	externalsecrets "github.com/openshift/external-secrets-operator/pkg/controller/external_secrets"
 	"github.com/openshift/external-secrets-operator/pkg/controller/common"
+	externalsecrets "github.com/openshift/external-secrets-operator/pkg/controller/external_secrets"
 	"github.com/openshift/external-secrets-operator/test/utils"
 )
 
@@ -160,7 +160,7 @@ var _ = Describe("External Secrets Operator End-to-End test scenarios", Ordered,
 		}
 	})
 
-	Context("AWS Secret Manager", Label("Platform:AWS"), func() {
+	Context("AWS Secret Manager", Label("Platform:AWS", "Provider:AWS"), func() {
 		const (
 			clusterSecretStoreFile           = "testdata/aws_secret_store.yaml"
 			externalSecretFile               = "testdata/aws_external_secret.yaml"
@@ -171,6 +171,13 @@ var _ = Describe("External Secrets Operator End-to-End test scenarios", Ordered,
 			awsClusterSecretStoreNamePattern = "${CLUSTERSECRETSTORE_NAME}"
 			awsSecretRegionName              = "ap-south-1"
 		)
+
+		BeforeAll(func() {
+			_, _, err := utils.FetchAWSCredsFromSecret(ctx, clientset, utils.AWSCredSecretName, utils.AWSCredNamespace)
+			Expect(err).NotTo(HaveOccurred(),
+				"AWS credentials secret %s/%s required (keys: aws_access_key_id, aws_secret_access_key). See test/e2e/README.md",
+				utils.AWSCredNamespace, utils.AWSCredSecretName)
+		})
 
 		AfterAll(func() {
 			By("Deleting the AWS secret")
@@ -258,7 +265,7 @@ var _ = Describe("External Secrets Operator End-to-End test scenarios", Ordered,
 		})
 	})
 
-	Context("Cross-platform: GCP cluster and AWS Secrets Manager", Label("CrossPlatform:GCP-AWS"), func() {
+	Context("Cross-platform: GCP cluster and AWS Secrets Manager", Label("Platform:GCP", "Provider:AWS"), func() {
 		const (
 			externalSecretFile               = "testdata/aws_external_secret.yaml"
 			pushSecretFile                   = "testdata/push_secret.yaml"
@@ -269,6 +276,13 @@ var _ = Describe("External Secrets Operator End-to-End test scenarios", Ordered,
 			awsSecretRegionName              = "ap-south-1"
 		)
 		var crossPlatformAWSSecretName string
+
+		BeforeAll(func() {
+			_, _, err := utils.FetchAWSCredsFromSecret(ctx, clientset, utils.AWSCredSecretName, utils.AWSCredNamespace)
+			Expect(err).NotTo(HaveOccurred(),
+				"AWS credentials secret %s/%s required (keys: aws_access_key_id, aws_secret_access_key). See test/e2e/README.md",
+				utils.AWSCredNamespace, utils.AWSCredSecretName)
+		})
 
 		AfterAll(func() {
 			if crossPlatformAWSSecretName != "" {
@@ -360,7 +374,7 @@ var _ = Describe("External Secrets Operator End-to-End test scenarios", Ordered,
 		})
 	})
 
-	Context("Environment Variables", func() {
+	Context("Environment Variables", Label("Platform:Generic", "Feature:OverrideEnv"), func() {
 		// Map component names to deployment names and target container names
 		componentToDeployment := map[string]string{
 			"ExternalSecretsCoreController": externalsecrets.OperandCoreControllerDeployment,
@@ -497,7 +511,7 @@ var _ = Describe("External Secrets Operator End-to-End test scenarios", Ordered,
 		})
 	})
 
-	Context("Deployment Revision History Limit", func() {
+	Context("Deployment Revision History Limit", Label("Platform:Generic", "Feature:RevisionHistoryLimit"), func() {
 		It("should use default revisionHistoryLimit when not configured", func() {
 			esc := &operatorv1alpha1.ExternalSecretsConfig{}
 			Expect(runtimeClient.Get(ctx, client.ObjectKey{Name: common.ExternalSecretsConfigObjectName}, esc)).To(Succeed())
@@ -581,7 +595,7 @@ var _ = Describe("External Secrets Operator End-to-End test scenarios", Ordered,
 		})
 	})
 
-	Context("UnsafeAllowGenericTargets feature", func() {
+	Context("UnsafeAllowGenericTargets feature", Label("Platform:Generic", "Feature:UnsafeAllowGenericTargets"), func() {
 		var (
 			originalFeatures []operatorv1alpha1.Feature
 			hadFeatures      bool
@@ -724,7 +738,7 @@ var _ = Describe("External Secrets Operator End-to-End test scenarios", Ordered,
 		})
 	})
 
-	Context("Annotations", func() {
+	Context("Annotations", Label("Platform:Generic", "Feature:CustomAnnotations"), func() {
 		It("should apply and remove custom annotations to created resources", func() {
 			// Define test annotations
 			testAnnotations := map[string]string{
@@ -867,7 +881,7 @@ var _ = Describe("External Secrets Operator End-to-End test scenarios", Ordered,
 		})
 	})
 
-	Context("Static Network Policy Naming", func() {
+	Context("Static Network Policy Naming", Label("Platform:Generic", "Feature:NetworkPolicy"), func() {
 		listManagedNetworkPolicies := func(ctx context.Context, namespace string) ([]networkingv1.NetworkPolicy, error) {
 			npList, err := clientset.NetworkingV1().NetworkPolicies(namespace).List(ctx, metav1.ListOptions{
 				LabelSelector: fmt.Sprintf("%s=%s,%s=%s", managedByLabel, managedByValue, partOfLabel, managedByValue),
@@ -925,7 +939,7 @@ var _ = Describe("External Secrets Operator End-to-End test scenarios", Ordered,
 		// TODO: Remove this test case after 3 releases(in v1.5.0) once the migration from
 		// unprefixed to eso-sys-/eso-user- network policy names is no longer needed.
 		It("should set the skip-np-cleanup-check annotation on ExternalSecretsConfig after migration",
-			Label("Migration", "PostUpgradeCheck"), func() {
+			Label("Feature:Upgrade"), func() {
 				By("Verifying the cleanup annotation is present on the CR")
 				Eventually(func(g Gomega) {
 					esc := &operatorv1alpha1.ExternalSecretsConfig{}
@@ -950,41 +964,14 @@ var _ = Describe("External Secrets Operator End-to-End test scenarios", Ordered,
 			})
 	})
 
-	Context("Custom Network Policy Naming", func() {
-		It("should prepend eso-user- prefix to custom network policies from CR spec", func() {
-			By("Verifying the ExternalSecretsConfig has custom network policies configured")
-			esc := &operatorv1alpha1.ExternalSecretsConfig{}
-			Expect(runtimeClient.Get(ctx, client.ObjectKey{Name: common.ExternalSecretsConfigObjectName}, esc)).To(Succeed())
-
-			if len(esc.Spec.ControllerConfig.NetworkPolicies) == 0 {
-				Skip("No custom network policies configured in ExternalSecretsConfig")
-			}
-
-			By("Checking that custom policies exist with eso-user- prefix")
-			Eventually(func(g Gomega) {
-				nps, err := clientset.NetworkingV1().NetworkPolicies(operandNamespace).List(ctx, metav1.ListOptions{
-					LabelSelector: fmt.Sprintf("%s=%s,%s=%s", managedByLabel, managedByValue, partOfLabel, managedByValue),
-				})
-				g.Expect(err).NotTo(HaveOccurred())
-
-				npNames := make(map[string]bool)
-				for _, np := range nps.Items {
-					npNames[np.Name] = true
-				}
-
-				for _, npConfig := range esc.Spec.ControllerConfig.NetworkPolicies {
-					expectedName := userNPPrefix + npConfig.Name
-					g.Expect(npNames).To(HaveKey(expectedName),
-						"custom network policy should exist as %s (with eso-user- prefix)", expectedName)
-				}
-			}, 2*time.Minute, 5*time.Second).Should(Succeed())
-		})
-
-		It("should create a custom network policy with eso-user- prefix via CR spec update", func() {
-			testPolicyName := "e2e-test-custom-egress"
+	Context("Custom Network Policy Naming", Label("Platform:Generic", "Feature:NetworkPolicy"), func() {
+		It("should create custom network policies with eso-user- prefix from CR spec", func() {
+			const testPolicyName = "e2e-test-custom-np"
 			expectedNPName := userNPPrefix + testPolicyName
 
-			By("Adding a custom network policy to the CR")
+			// networkPolicies name/componentName are immutable (CEL); entries cannot be removed after creation.
+			// Add the test policy if missing, then verify the operator materializes it in the operand namespace.
+			By("Adding a custom network policy with a dummy egress port to ExternalSecretsConfig")
 			tcp := corev1.ProtocolTCP
 			port8443 := intstr.FromInt32(8443)
 			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
@@ -992,13 +979,11 @@ var _ = Describe("External Secrets Operator End-to-End test scenarios", Ordered,
 				if err := runtimeClient.Get(ctx, client.ObjectKey{Name: common.ExternalSecretsConfigObjectName}, currentCR); err != nil {
 					return err
 				}
-
 				for _, np := range currentCR.Spec.ControllerConfig.NetworkPolicies {
 					if np.Name == testPolicyName {
 						return nil
 					}
 				}
-
 				currentCR.Spec.ControllerConfig.NetworkPolicies = append(
 					currentCR.Spec.ControllerConfig.NetworkPolicies,
 					operatorv1alpha1.NetworkPolicy{
@@ -1015,21 +1000,24 @@ var _ = Describe("External Secrets Operator End-to-End test scenarios", Ordered,
 				)
 				return runtimeClient.Update(ctx, currentCR)
 			})
-			Expect(err).NotTo(HaveOccurred(), "should add custom network policy to CR")
+			Expect(err).NotTo(HaveOccurred(), "should add custom network policy to ExternalSecretsConfig")
 
-			By("Waiting for custom network policy to be created with eso-user- prefix")
+			By("Waiting for custom network policy to be created with eso-user- prefix in operand namespace")
 			Eventually(func(g Gomega) {
 				np, err := clientset.NetworkingV1().NetworkPolicies(operandNamespace).Get(ctx, expectedNPName, metav1.GetOptions{})
-				g.Expect(err).NotTo(HaveOccurred(), "custom network policy %s should exist", expectedNPName)
+				g.Expect(err).NotTo(HaveOccurred(), "custom network policy %s should exist in %s", expectedNPName, operandNamespace)
+				g.Expect(np.Spec.PolicyTypes).To(ContainElement(networkingv1.PolicyTypeEgress))
 				g.Expect(np.Spec.Egress).To(HaveLen(1))
 				g.Expect(np.Spec.Egress[0].Ports).To(HaveLen(1))
+				g.Expect(np.Spec.Egress[0].Ports[0].Port).NotTo(BeNil())
+				g.Expect(np.Spec.Egress[0].Ports[0].Port.IntVal).To(Equal(int32(8443)))
 			}, 2*time.Minute, 5*time.Second).Should(Succeed())
 		})
 	})
 
-	// Tests labeled with "Proxy:HTTP" should only be run when a cluster-wide
+	// Tests labeled with Feature:Proxy should only be run when a cluster-wide
 	// OpenShift egress proxy is already configured via proxy.config.openshift.io/cluster object
-	Context("Proxy Egress Network Policy", Label("Platform:Generic"), Label("Proxy:HTTP"), func() {
+	Context("Proxy Egress Network Policy", Label("Platform:Generic", "Feature:Proxy"), func() {
 		var clusterProxyPorts []int32
 		var originalProxy *operatorv1alpha1.ProxyConfig
 
@@ -1075,7 +1063,7 @@ var _ = Describe("External Secrets Operator End-to-End test scenarios", Ordered,
 		})
 
 		// Cluster-wide proxy configuration consumed via OLM env vars.
-		It("should create proxy egress policy when configured with Managed provisioning", Label("Proxy:HTTP"), func() {
+		It("should create proxy egress policy when configured with Managed provisioning", func() {
 			By("Setting proxy configuration with Managed network policy provisioning")
 			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 				currentCR := &operatorv1alpha1.ExternalSecretsConfig{}
@@ -1203,7 +1191,7 @@ var _ = Describe("External Secrets Operator End-to-End test scenarios", Ordered,
 	// Resources intentionally excluded:
 	//   - Deployment: Kubernetes adds deployment.kubernetes.io/revision on every rollout,
 	//     so annotation events are suppressed to avoid infinite reconcile loops.
-	Context("Managed Annotation Restoration", Ordered, Label("Platform:AWS"), func() {
+	Context("Managed Annotation Restoration", Ordered, Label("Platform:Generic", "Feature:CustomAnnotations"), func() {
 		const (
 			restorationAnnotationKey   = "example.com/restoration-test"
 			restorationAnnotationValue = "managed-value"
@@ -1464,7 +1452,7 @@ var _ = Describe("External Secrets Operator End-to-End test scenarios", Ordered,
 	// causes the operator to remove it from all resources. This exercises the full
 	// label lifecycle across every resource type, including the co-managed Secret whose
 	// metadata is patched via JSON Patch rather than a full update.
-	Context("Custom Labels", Label("Platform:AWS"), func() {
+	Context("Custom Labels", Label("Platform:Generic", "Feature:CustomLabels"), func() {
 		AfterEach(func() {
 			By("Verifying ExternalSecretsConfig is Ready and not Degraded after label lifecycle test")
 			Expect(utils.WaitForExternalSecretsConfigReady(ctx, dynamicClient, "cluster", 2*time.Minute)).To(Succeed(),
@@ -1575,7 +1563,7 @@ var _ = Describe("External Secrets Operator End-to-End test scenarios", Ordered,
 		})
 	})
 
-	Context("Managed Label Restoration", Label("Platform:AWS"), func() {
+	Context("Managed Label Restoration", Label("Platform:Generic", "Feature:CustomLabels"), func() {
 		const (
 			managedLabelKey   = "app"
 			managedLabelValue = "external-secrets"

--- a/test/e2e/trusted_ca_bundle_test.go
+++ b/test/e2e/trusted_ca_bundle_test.go
@@ -37,6 +37,7 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -94,7 +95,7 @@ func testLeafCertPEM() string {
 	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
 }
 
-var _ = Describe("Trusted CA Bundle", Ordered, func() {
+var _ = Describe("Trusted CA Bundle", Ordered, Label("Platform:Generic", "Feature:TrustedCABundle"), func() {
 	var (
 		ctx context.Context
 		esc *operatorv1alpha1.ExternalSecretsConfig
@@ -332,26 +333,42 @@ var _ = Describe("Trusted CA Bundle", Ordered, func() {
 		}, time.Minute, 5*time.Second).Should(Succeed(), "core controller should have user CA bundle after recovery")
 	})
 
-	It("should mount user-ca-bundle when ConfigMap has the CNO inject label but no proxy is configured", func() {
+	It("should handle trustedCABundle ConfigMap with CNO inject label based on cluster proxy", func() {
+		clusterProxyConfigured := isOpenShiftClusterProxyConfigured(ctx)
+
 		By("Creating a ConfigMap with the CNO inject label")
 		createTestCAConfigMap(ctx, trustedCABundleTestCMName, externalsecrets.UserCABundleKeyPath, testCACertPEM(), map[string]string{
 			externalsecrets.TrustedCABundleInjectLabel: "true",
 		})
 
-		By("Setting trustedCABundle on ExternalSecretsConfig")
+		By("Setting trustedCABundle on ExternalSecretsConfig (no proxy in ESC spec)")
 		setTrustedCABundle(ctx, trustedCABundleTestCMName, externalsecrets.UserCABundleKeyPath)
 
-		By("Waiting for ExternalSecretsConfig to be Ready — skip requires CNO label and proxy")
+		By("Waiting for ExternalSecretsConfig to be Ready")
 		Expect(utils.WaitForExternalSecretsConfigReady(ctx, suiteDynamicClient, common.ExternalSecretsConfigObjectName, 2*time.Minute)).To(Succeed())
 
-		By("Verifying the core controller deployment has the user-ca-bundle volume")
+		if clusterProxyConfigured {
+			By("Verifying user CA mount is skipped and operator-managed trusted-ca-bundle is used when cluster proxy is configured")
+			Eventually(func(g Gomega) {
+				deployment, err := suiteClientset.AppsV1().Deployments(operandNamespace).Get(ctx, externalsecrets.OperandCoreControllerDeployment, metav1.GetOptions{})
+				g.Expect(err).NotTo(HaveOccurred())
+				assertDoesNotHaveUserCABundleVolume(g, deployment.Spec.Template.Spec.Volumes)
+				assertDoesNotHaveUserCABundleMount(g, deployment.Spec.Template.Spec.Containers)
+				assertDoesNotHaveSSLCertDir(g, deployment.Spec.Template.Spec.Containers)
+				assertHasProxyTrustedCABundleVolume(g, deployment.Spec.Template.Spec.Volumes)
+			}, time.Minute, 5*time.Second).Should(Succeed(),
+				"CNO-managed ConfigMap with cluster proxy should use operator trusted-ca-bundle, not user-ca-bundle")
+			return
+		}
+
+		By("Verifying the core controller deployment has the user-ca-bundle volume when cluster proxy is not configured")
 		Eventually(func(g Gomega) {
 			deployment, err := suiteClientset.AppsV1().Deployments(operandNamespace).Get(ctx, externalsecrets.OperandCoreControllerDeployment, metav1.GetOptions{})
 			g.Expect(err).NotTo(HaveOccurred())
 			assertHasUserCABundleVolume(g, deployment.Spec.Template.Spec.Volumes, trustedCABundleTestCMName)
 			assertHasSSLCertDir(g, deployment.Spec.Template.Spec.Containers, externalsecrets.OperandCoreControllerContainer)
 		}, time.Minute, 5*time.Second).Should(Succeed(),
-			"volume should be mounted when CNO label is present but no proxy is configured")
+			"volume should be mounted when CNO label is present but cluster proxy is not configured")
 	})
 })
 
@@ -436,6 +453,38 @@ func assertDoesNotHaveUserCABundleVolume(g Gomega, volumes []corev1.Volume) {
 		g.Expect(v.Name).NotTo(Equal(externalsecrets.UserCABundleVolumeName),
 			"volumes should not contain %s", externalsecrets.UserCABundleVolumeName)
 	}
+}
+
+func assertHasProxyTrustedCABundleVolume(g Gomega, volumes []corev1.Volume) {
+	g.Expect(volumes).To(ContainElement(
+		SatisfyAll(
+			HaveField("Name", externalsecrets.ProxyTrustedCABundleVolumeName),
+			HaveField("VolumeSource.ConfigMap", Not(BeNil())),
+			HaveField("VolumeSource.ConfigMap.LocalObjectReference.Name", externalsecrets.ProxyTrustedCABundleConfigMapName),
+		),
+	), "volumes should contain %s sourced from ConfigMap %s",
+		externalsecrets.ProxyTrustedCABundleVolumeName, externalsecrets.ProxyTrustedCABundleConfigMapName)
+}
+
+func isOpenShiftClusterProxyConfigured(ctx context.Context) bool {
+	proxyGVR := schema.GroupVersionResource{
+		Group:    "config.openshift.io",
+		Version:  "v1",
+		Resource: "proxies",
+	}
+	proxyCR, err := suiteDynamicClient.Resource(proxyGVR).Get(ctx, common.ExternalSecretsConfigObjectName, metav1.GetOptions{})
+	if err != nil {
+		return false
+	}
+	for _, section := range []string{"status", "spec"} {
+		httpProxy, _, _ := unstructured.NestedString(proxyCR.Object, section, "httpProxy")
+		httpsProxy, _, _ := unstructured.NestedString(proxyCR.Object, section, "httpsProxy")
+		noProxy, _, _ := unstructured.NestedString(proxyCR.Object, section, "noProxy")
+		if httpProxy != "" || httpsProxy != "" || noProxy != "" {
+			return true
+		}
+	}
+	return false
 }
 
 func assertHasUserCABundleMount(g Gomega, containers []corev1.Container, containerName string) {

--- a/test/utils/bitwarden.go
+++ b/test/utils/bitwarden.go
@@ -70,9 +70,12 @@ const (
 // "token" matches the official external-secrets.io Bitwarden provider example.
 const TokenSecretKey = "token"
 
-// Bitwarden credentials secret (fixed name/namespace for e2e, like AWS aws-creds).
-// Document in docs/e2e/README.md. Keys: token, organization_id, project_id.
 const (
+	// BitwardenTLSSecretName is the Kubernetes secret created by e2e tests for the bitwarden-sdk-server
+	// plugin (keys: tls.crt, tls.key, ca.crt). Referenced by ExternalSecretsConfig secretRef — not bitwarden-creds.
+	BitwardenTLSSecretName = "bitwarden-tls-certs"
+	// Bitwarden credentials secret (fixed name/namespace for live Bitwarden cloud API e2e).
+	// Document in test/e2e/README.md. Keys: token, organization_id, project_id.
 	BitwardenCredSecretName      = "bitwarden-creds"
 	BitwardenCredSecretNamespace = common.ExternalSecretsOperatorCommonName
 	BitwardenCredKeyOrgID        = "organization_id"

--- a/test/utils/bitwarden_api_runner.go
+++ b/test/utils/bitwarden_api_runner.go
@@ -42,6 +42,12 @@ func BitwardenCredMountPath() string {
 	return bitwardenCredMountPath
 }
 
+// RunBitwardenCurlJob runs a one-off curl Job in the given namespace without mounting Bitwarden credentials.
+// Used by API:Bitwarden health and auth tests that only need reachability to bitwarden-sdk-server.
+func RunBitwardenCurlJob(ctx context.Context, client kubernetes.Interface, namespace, jobName string, command []string, timeout time.Duration) (exitCode int, logs string, err error) {
+	return runBitwardenJob(ctx, client, namespace, jobName, command, timeout, false)
+}
+
 // RunBitwardenAPIJob runs a one-off Job in the given namespace with the Bitwarden cred secret mounted.
 // The job runs the given command (e.g. a shell script that curls the Bitwarden API and exits 0 on success).
 // Returns the container exit code (0 = success), pod logs, and any error (e.g. timeout, job failed).
@@ -49,7 +55,32 @@ func BitwardenCredMountPath() string {
 // Job spec is minimal (no security context); the platform (e.g. OpenShift SCC) mutates as needed.
 // Pod label app.kubernetes.io/name=external-secrets matches the network policy so the Job can reach bitwarden-sdk-server.
 func RunBitwardenAPIJob(ctx context.Context, client kubernetes.Interface, namespace, jobName string, command []string, timeout time.Duration) (exitCode int, logs string, err error) {
+	return runBitwardenJob(ctx, client, namespace, jobName, command, timeout, true)
+}
+
+func runBitwardenJob(ctx context.Context, client kubernetes.Interface, namespace, jobName string, command []string, timeout time.Duration, mountCreds bool) (exitCode int, logs string, err error) {
 	backOffLimit := int32(0)
+	container := corev1.Container{
+		Name:    "curl",
+		Image:   bitwardenAPITestRunnerImage,
+		Command: command,
+	}
+	var volumes []corev1.Volume
+	if mountCreds {
+		container.VolumeMounts = []corev1.VolumeMount{{
+			Name:      "bitwarden-cred",
+			MountPath: bitwardenCredMountPath,
+			ReadOnly:  true,
+		}}
+		volumes = []corev1.Volume{{
+			Name: "bitwarden-cred",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: BitwardenCredSecretName,
+				},
+			},
+		}}
+	}
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      jobName,
@@ -63,24 +94,8 @@ func RunBitwardenAPIJob(ctx context.Context, client kubernetes.Interface, namesp
 				},
 				Spec: corev1.PodSpec{
 					RestartPolicy: corev1.RestartPolicyNever,
-					Containers: []corev1.Container{{
-						Name:    "curl",
-						Image:   bitwardenAPITestRunnerImage,
-						Command: command,
-						VolumeMounts: []corev1.VolumeMount{{
-							Name:      "bitwarden-cred",
-							MountPath: bitwardenCredMountPath,
-							ReadOnly:  true,
-						}},
-					}},
-					Volumes: []corev1.Volume{{
-						Name: "bitwarden-cred",
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{
-								SecretName: BitwardenCredSecretName,
-							},
-						},
-					}},
+					Containers:    []corev1.Container{container},
+					Volumes:       volumes,
 				},
 			},
 		},

--- a/test/utils/conditions.go
+++ b/test/utils/conditions.go
@@ -44,7 +44,7 @@ import (
 
 const (
 	// AWSCredSecretName and AWSCredNamespace are the fixed name and namespace for the K8s secret
-	// that holds AWS credentials (e.g. for Platform:AWS and CrossPlatform:GCP-AWS e2e). Document in docs/e2e.
+	// that holds AWS credentials (e.g. for Provider:AWS e2e on Platform:AWS or Platform:GCP). Document in test/e2e/README.md.
 	AWSCredSecretName             = "aws-creds"
 	AWSCredNamespace              = "kube-system"
 	awsCredSecretName             = AWSCredSecretName


### PR DESCRIPTION
## Summary

- Introduce a structured Ginkgo label taxonomy (`Platform`, `Provider`, `Feature`, `API`) across e2e suites and update the Makefile default filter to run portable + AWS tests while excluding Bitwarden provider, proxy, and upgrade checks.
- Remove runtime `Skip()` calls: selected specs now fail fast when prerequisites (secrets, cluster config) are missing; label filters are the opt-in mechanism.
- Refactor Bitwarden API setup to auto-provision `bitwarden-tls-certs` and enable the SDK server plugin via `ensureBitwardenOperandReady`; only `Provider:Bitwarden` specs require pre-provisioned `bitwarden-creds`.
- Rewrite `test/e2e/README.md` with label keys, filter recipes, prerequisites, and local/CI artifact output (`ARTIFACT_DIR` / `_output`).

## Changes

### Labeling
- Add `Feature:*` labels to previously unlabeled contexts (`OverrideEnv`, `RevisionHistoryLimit`, `UnsafeAllowGenericTargets`, `CustomAnnotations`, `NetworkPolicy`, `TrustedCABundle`, etc.).
- Replace ad hoc labels (`CrossPlatform:GCP-AWS`, `Proxy:HTTP`, `PostUpgradeCheck`, `Suite:Bitwarden`) with `Platform:GCP` + `Provider:AWS`, `Feature:Proxy`, `Feature:Upgrade`, etc.
- Tag Bitwarden Secrets API context with `Provider:Bitwarden` so default CI runs health/auth only.

### Makefile
- Default filter:
```bash
Platform: isSubsetOf {AWS,Generic} && !(Feature: containsAny {Proxy, Upgrade}) && !(Provider: containsAny Bitwarden)
```
- Use `{Proxy, Upgrade}` brace syntax so Ginkgo parses `containsAny` correctly (comma is otherwise treated as OR).

### Test behavior
- Replace credential/config skips with `Expect` failures for `Provider:AWS`, `Platform:GCP`, and `Provider:Bitwarden`.
- Custom network policy test adds a dummy egress rule to ExternalSecretsConfig and verifies `eso-user-*` creation (no CR removal — CEL immutability).
- Trusted CA bundle test adapts to cluster proxy state (checks `spec` and `status` on `proxy.config.openshift.io/cluster`).
- Extract shared Bitwarden setup into `test/e2e/bitwarden_helpers_test.go`; add `RunBitwardenCurlJob` for cred-less API health/auth tests.

## Test plan

- [x] Dry-run default filter and confirm expected run/skip counts:
```bash
go test -C test -tags e2e -count=1 -p 1 ./e2e -ginkgo.dry-run \
  -ginkgo.label-filter='Platform: isSubsetOf {AWS,Generic} && !(Feature: containsAny {Proxy, Upgrade}) && !(Provider: containsAny Bitwarden)'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded end-to-end test selection options with clearer label-based filtering and documented suite recipes.
  * Added support for Bitwarden API checks without requiring credential mounts.
  * Improved trusted CA bundle handling when an OpenShift proxy is configured.

* **Bug Fixes**
  * Tightened E2E test requirements so missing prerequisites now fail clearly instead of being skipped.
  * Updated Bitwarden and network policy test flows for more reliable setup and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->