### PR TITLE
ART-14816: Add package.yaml for ART OLM bundle generation

### DIFF
--- a/bundle/external-secrets-operator.package.yaml
+++ b/bundle/external-secrets-operator.package.yaml
@@ -1,0 +1,6 @@
+---
+packageName: openshift-external-secrets-operator
+channels:
+- name: stable
+  currentCSV: openshift-external-secrets-operator.v1.1.0
+defaultChannel: stable


### PR DESCRIPTION
## Problem Statement

ART's OLM bundler (Doozer) requires a `*.package.yaml` file in the `bundle/` directory for bundle rebase. Without it, the `olm_bundle_konflux` job fails with `IndexError: list index out of range`.

## Related Issue

Part of [ART-14816](https://redhat.atlassian.net/browse/ART-14816) (Onboard OAP operators to ART).

## Proposed Changes

Add `bundle/external-secrets-operator.package.yaml` — same pattern used by OADP (`oadp-operator.package.yaml`) and Logging (`cluster-logging-operator.package.yaml`).