### PR TITLE
[release-1.1] ART-14816: Update bundle package.yaml channel and CSV version

### DIFF
--- a/bundle/external-secrets-operator.package.yaml
+++ b/bundle/external-secrets-operator.package.yaml
@@ -1,6 +1,6 @@
 ---
 packageName: openshift-external-secrets-operator
 channels:
-- name: alpha
+- name: stable-v1
   currentCSV: openshift-external-secrets-operator.v1.1.1
-defaultChannel: alpha
+defaultChannel: stable-v1

--- a/bundle/external-secrets-operator.package.yaml
+++ b/bundle/external-secrets-operator.package.yaml
@@ -1,6 +1,6 @@
 ---
 packageName: openshift-external-secrets-operator
 channels:
-- name: stable
-  currentCSV: openshift-external-secrets-operator.v1.1.0
-defaultChannel: stable
+- name: alpha
+  currentCSV: openshift-external-secrets-operator.v1.1.1
+defaultChannel: alpha


### PR DESCRIPTION
## Summary
- Change channel from `stable` to `alpha` to match upstream production bundle annotations
- Bump currentCSV from `v1.1.0` to `v1.1.1` to match CSV version

## Context
Production bundle annotations use `alpha` as the channel name. Our `package.yaml` had `stable` which caused a mismatch. The CSV version was also bumped upstream to v1.1.1.

## Test plan
- [ ] Verify bundle build produces correct `annotations.yaml` with `channels.v1: alpha`
