### PR TITLE
ai-eval: DNM, ESO-203: Requeue when ExternalSecretsConfig CR is not found

### DIFF
--- a/pkg/controller/external_secrets/controller.go
+++ b/pkg/controller/external_secrets/controller.go
@@ -410,11 +410,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	esc := &operatorv1alpha1.ExternalSecretsConfig{}
 	if err := r.Get(ctx, req.NamespacedName, esc); err != nil {
 		if errors.IsNotFound(err) {
-			// NotFound errors, since they can't be fixed by an immediate
-			// requeue (have to wait for a new notification), and can be processed
-			// on deleted requests.
-			r.log.V(1).Info("externalsecretsconfigs.operator.openshift.io object not found, skipping reconciliation", "request", req)
-			return ctrl.Result{}, nil
+			// Requeue so the controller retries once the CR appears. Without this,
+			// a race between cache sync and CR creation (common in GitOps flows)
+			// can leave the controller stuck until the pod is restarted.
+			r.log.V(1).Info("externalsecretsconfigs.operator.openshift.io object not found, will retry", "request", req)
+			return ctrl.Result{RequeueAfter: common.DefaultRequeueTime}, nil
 		}
 		return ctrl.Result{}, fmt.Errorf("failed to fetch externalsecretsconfigs.operator.openshift.io %q during reconciliation: %w", req.NamespacedName, err)
 	}

--- a/pkg/controller/external_secrets_manager/controller.go
+++ b/pkg/controller/external_secrets_manager/controller.go
@@ -152,10 +152,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 	if err := r.Get(ctx, key, r.esc); err != nil {
 		if errors.IsNotFound(err) {
-			// NotFound errors, would mean the object hasn't been created yet and
-			// not required to reconcile yet.
-			r.log.V(1).Info("externalsecretsconfigs.operator.openshift.io object not found, skipping reconciliation", "key", key)
-			return ctrl.Result{}, nil
+			// Requeue so the controller retries once the CR appears. Without this,
+			// a race between cache sync and CR creation (common in GitOps flows)
+			// can leave the controller stuck until the pod is restarted.
+			r.log.V(1).Info("externalsecretsconfigs.operator.openshift.io object not found, will retry", "key", key)
+			return ctrl.Result{RequeueAfter: common.DefaultRequeueTime}, nil
 		}
 		return ctrl.Result{}, fmt.Errorf("failed to fetch externalsecretsconfigs.operator.openshift.io %q during reconciliation: %w", key, err)
 	}

--- a/pkg/controller/external_secrets_manager/controller_test.go
+++ b/pkg/controller/external_secrets_manager/controller_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr/testr"
 
@@ -55,6 +56,7 @@ func TestReconcile(t *testing.T) {
 		preReq                  func(*Reconciler, *fakes.FakeCtrlClient)
 		expectedStatusCondition []operatorv1alpha1.ControllerStatus
 		wantErr                 string
+		wantRequeueAfter        time.Duration
 	}{
 		{
 			name: "esm reconciliation successful",
@@ -135,7 +137,7 @@ func TestReconcile(t *testing.T) {
 			wantErr:                 `failed to fetch externalsecretsmanagers.operator.openshift.io "/cluster" during reconciliation: externalsecretsmanagers.operator.openshift.io "cluster" not found`,
 		},
 		{
-			name: "externalsecretsconfig object not found",
+			name: "externalsecretsconfig object not found requeues",
 			preReq: func(r *Reconciler, m *fakes.FakeCtrlClient) {
 				m.GetCalls(func(ctx context.Context, ns types.NamespacedName, obj client.Object) error {
 					switch o := obj.(type) {
@@ -154,6 +156,7 @@ func TestReconcile(t *testing.T) {
 				})
 			},
 			expectedStatusCondition: []operatorv1alpha1.ControllerStatus{},
+			wantRequeueAfter:        common.DefaultRequeueTime,
 		},
 		{
 			name: "externalsecretsconfig fetch fails",
@@ -278,7 +281,7 @@ func TestReconcile(t *testing.T) {
 			}
 			r.CtrlClient = mock
 			esm = &operatorv1alpha1.ExternalSecretsManager{}
-			_, err := r.Reconcile(context.Background(), ctrl.Request{
+			result, err := r.Reconcile(context.Background(), ctrl.Request{
 				NamespacedName: types.NamespacedName{
 					Name: common.ExternalSecretsManagerObjectName,
 				},
@@ -286,6 +289,9 @@ func TestReconcile(t *testing.T) {
 
 			if (tt.wantErr != "" || err != nil) && (err == nil || err.Error() != tt.wantErr) {
 				t.Errorf("Reconcile() err: %v, wantErr: %v", err, tt.wantErr)
+			}
+			if result.RequeueAfter != tt.wantRequeueAfter {
+				t.Errorf("Reconcile() RequeueAfter = %v, want %v", result.RequeueAfter, tt.wantRequeueAfter)
 			}
 			for _, c1 := range esm.Status.ControllerStatuses {
 				for _, c2 := range tt.expectedStatusCondition {


### PR DESCRIPTION
## Summary
- Fixes a race condition where the operator fails to reconcile when the `ExternalSecretsConfig` CR arrives after the controller's initial cache sync (common in GitOps/ArgoCD deployments).
- Both the `external-secrets` and `external-secrets-manager` controllers now requeue with a 30-second delay when the CR is not found, instead of silently giving up.
- Adds test coverage verifying the requeue behavior.

## Test plan
- [x] Unit tests pass for `pkg/controller/external_secrets/...`
- [x] Unit tests pass for `pkg/controller/external_secrets_manager/...`
- [x] Full `pkg/...` test suite passes with no regressions
- [ ] Manual verification with GitOps deployment (ArgoCD applying subscription + operatorgroup + ExternalSecretsConfig simultaneously)

Always review AI generated responses prior to use.
Generated with [Claude Code](https://claude.com/claude-code) via openshift-developer plugin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reconciliation reliability when the external secrets configuration is temporarily unavailable.
  * The system now automatically retries after the default interval instead of stopping without a follow-up attempt.

* **Tests**
  * Added coverage to verify retry timing and reconciliation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->