### PR TITLE
fix(controller): ESO-481 fix secondary watch predicates

### DIFF
--- a/.work/solve/spec-ESO-481.md
+++ b/.work/solve/spec-ESO-481.md
@@ -1,0 +1,58 @@
+# ESO-481: Fix ConfigMap secondary watch predicate
+
+## Problem
+
+Secondary watches use label predicates to decide which operand/user resources
+should enqueue `ExternalSecretsConfig` reconciliation.
+
+`managedResources` already correctly checks both `ObjectOld` and `ObjectNew` on
+update events (via inline `predicate.Funcs{}`). However,
+`managedOrWatchedResources` — used for ConfigMaps including user
+`trustedCABundle` references — is built with `predicate.NewPredicateFuncs()`,
+which only inspects `ObjectNew`.
+
+**Impact**: When a watched label is present on the old object but removed on the
+new object, the event is filtered out before reconcile runs, breaking
+self-healing for watched ConfigMaps.
+
+## Root Cause
+
+`predicate.NewPredicateFuncs(f)` creates a predicate where all event types
+(Create, Update, Delete, Generic) pass `f` only the single object available.
+For `UpdateFunc` specifically, it evaluates **only `ObjectNew`**, unlike the
+hand-rolled `predicate.Funcs{}` block for `managedResources` that checks
+`e.ObjectOld || e.ObjectNew`.
+
+## Solution
+
+1. **Extract `labelMatchPredicate` helper** in `utils.go` that accepts a
+   `func(client.Object) bool` and returns a `predicate.Funcs` checking both
+   old and new objects on updates.
+
+2. **Extract package-level `isManagedResource` and `isManagedOrWatchedResource`**
+   functions from the inline closure in `SetupWithManager`, making them
+   reusable and testable.
+
+3. **Refactor `controller.go`** to replace both the inline `predicate.Funcs{}`
+   block AND `predicate.NewPredicateFuncs()` with calls to
+   `labelMatchPredicate(isManagedResource)` and
+   `labelMatchPredicate(isManagedOrWatchedResource)`.
+
+4. **Add unit tests** verifying that the predicate correctly admits update
+   events when:
+   - Only old object has the label (label removed — the critical fix)
+   - Only new object has the label (label added)
+   - Both objects have the label
+   - Neither object has the label (should filter)
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `pkg/controller/external_secrets/utils.go` | Add `isManagedResource`, `isManagedOrWatchedResource`, `labelMatchPredicate` |
+| `pkg/controller/external_secrets/controller.go` | Replace inline predicates with helper calls, remove unused `event` import |
+| `pkg/controller/external_secrets/utils_test.go` | Add `TestLabelMatchPredicateUpdate` and `TestLabelMatchPredicateCreateDeleteGeneric` |
+
+## Commit Plan
+
+Single commit: `fix(controller): ESO-481 fix secondary watch predicates to evaluate old and new objects on update`

--- a/pkg/controller/external_secrets/controller.go
+++ b/pkg/controller/external_secrets/controller.go
@@ -40,7 +40,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -286,36 +285,12 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return []reconcile.Request{}
 	}
 
-	// On updates, check both old and new objects so that events where the managed
-	// label is removed externally still trigger reconciliation and label restoration.
-	isManagedResource := func(object client.Object) bool {
-		labels := object.GetLabels()
-		return labels != nil && labels[ManagedResourceLabelKey] == ManagedResourceLabelValue
-	}
-	managedResources := predicate.Funcs{
-		CreateFunc: func(e event.CreateEvent) bool {
-			return isManagedResource(e.Object)
-		},
-		UpdateFunc: func(e event.UpdateEvent) bool {
-			return isManagedResource(e.ObjectOld) || isManagedResource(e.ObjectNew)
-		},
-		DeleteFunc: func(e event.DeleteEvent) bool {
-			return isManagedResource(e.Object)
-		},
-		GenericFunc: func(e event.GenericEvent) bool {
-			return isManagedResource(e.Object)
-		},
-	}
+	// managedResources limits enqueues to operator-managed operand resources (app=external-secrets).
+	managedResources := labelMatchPredicate(isManagedResource)
 
-	// managedOrWatchedResources limits enqueues to operator-managed resources (app=external-secrets) and
-	// user referenced resources (like ConfigMaps) having the watch label (externalsecretsconfig.operator.openshift.io/watching)
-	// so unrelated resource changes do not trigger reconciliation.
-	managedOrWatchedResources := predicate.NewPredicateFuncs(func(object client.Object) bool {
-		if object.GetLabels() == nil {
-			return false
-		}
-		return hasManagedOrWatchLabel(object.GetLabels())
-	})
+	// managedOrWatchedResources also admits user referenced resources (like trustedCABundle
+	// ConfigMaps) labeled externalsecretsconfig.operator.openshift.io/watching.
+	managedOrWatchedResources := labelMatchPredicate(isManagedOrWatchedResource)
 
 	// Resources like Deployments are reconciled on spec generation or managed-label changes.
 	withIgnoreStatusUpdatePredicates := builder.WithPredicates(

--- a/pkg/controller/external_secrets/utils.go
+++ b/pkg/controller/external_secrets/utils.go
@@ -16,6 +16,8 @@ import (
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"go.uber.org/zap/zapcore"
 
@@ -264,6 +266,46 @@ func (r *Reconciler) isProxyEnabled() bool {
 func hasManagedOrWatchLabel(labels map[string]string) bool {
 	return labels[ManagedResourceLabelKey] == ManagedResourceLabelValue ||
 		labels[WatchedResourceLabelKey] == WatchedResourceLabelValue
+}
+
+// isManagedResource reports whether object is an operator-managed operand resource.
+func isManagedResource(object client.Object) bool {
+	if object == nil {
+		return false
+	}
+	labels := object.GetLabels()
+	return labels != nil && labels[ManagedResourceLabelKey] == ManagedResourceLabelValue
+}
+
+// isManagedOrWatchedResource reports whether object is an operator-managed operand or a
+// user-provided resource labeled for passive watch (e.g. trustedCABundle ConfigMaps).
+func isManagedOrWatchedResource(object client.Object) bool {
+	if object == nil {
+		return false
+	}
+	labels := object.GetLabels()
+	return labels != nil && hasManagedOrWatchLabel(labels)
+}
+
+// labelMatchPredicate builds a predicate that admits events when the supplied match
+// function returns true. On Update events it evaluates both ObjectOld and ObjectNew so
+// that reconciliation still fires when a qualifying label is removed externally (the old
+// object matches even though the new one does not).
+func labelMatchPredicate(match func(client.Object) bool) predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return match(e.Object)
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return match(e.ObjectOld) || match(e.ObjectNew)
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return match(e.Object)
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return match(e.Object)
+		},
+	}
 }
 
 // getWithCacheFallback reads a resource from the manager cache first. On IsNotFound it

--- a/pkg/controller/external_secrets/utils_test.go
+++ b/pkg/controller/external_secrets/utils_test.go
@@ -10,6 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	operatorv1alpha1 "github.com/openshift/external-secrets-operator/api/v1alpha1"
 	"github.com/openshift/external-secrets-operator/pkg/controller/client/fakes"
@@ -436,6 +437,157 @@ func TestUpdateWatchLabel(t *testing.T) {
 			}
 			if tt.wantPatch && !patched {
 				t.Fatal("expected Patch to be called")
+			}
+		})
+	}
+}
+
+func TestLabelMatchPredicateUpdate(t *testing.T) {
+	t.Parallel()
+
+	watchLabels := map[string]string{WatchedResourceLabelKey: WatchedResourceLabelValue}
+	managedLabels := map[string]string{ManagedResourceLabelKey: ManagedResourceLabelValue}
+
+	tests := []struct {
+		name      string
+		oldLabels map[string]string
+		newLabels map[string]string
+		want      bool
+	}{
+		{
+			name:      "both old and new watched",
+			oldLabels: watchLabels,
+			newLabels: watchLabels,
+			want:      true,
+		},
+		{
+			name:      "old watched only — label removed",
+			oldLabels: watchLabels,
+			newLabels: map[string]string{"foo": "bar"},
+			want:      true,
+		},
+		{
+			name:      "new watched only — label added",
+			oldLabels: nil,
+			newLabels: watchLabels,
+			want:      true,
+		},
+		{
+			name:      "neither watched",
+			oldLabels: map[string]string{"foo": "bar"},
+			newLabels: map[string]string{"foo": "bar"},
+			want:      false,
+		},
+		{
+			name:      "managed label on old only",
+			oldLabels: managedLabels,
+			newLabels: map[string]string{"foo": "bar"},
+			want:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			updateEvent := event.UpdateEvent{
+				ObjectOld: &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Labels: tt.oldLabels}},
+				ObjectNew: &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Labels: tt.newLabels}},
+			}
+
+			gotManaged := labelMatchPredicate(isManagedResource).Update(updateEvent)
+			wantManaged := isManagedResource(updateEvent.ObjectOld) || isManagedResource(updateEvent.ObjectNew)
+			if gotManaged != wantManaged {
+				t.Fatalf("managed Update() = %v, want %v", gotManaged, wantManaged)
+			}
+
+			gotManagedOrWatched := labelMatchPredicate(isManagedOrWatchedResource).Update(updateEvent)
+			if gotManagedOrWatched != tt.want {
+				t.Fatalf("managedOrWatched Update() = %v, want %v", gotManagedOrWatched, tt.want)
+			}
+		})
+	}
+}
+
+func TestLabelMatchPredicateCreateDeleteGeneric(t *testing.T) {
+	t.Parallel()
+
+	watchLabels := map[string]string{WatchedResourceLabelKey: WatchedResourceLabelValue}
+	managedLabels := map[string]string{ManagedResourceLabelKey: ManagedResourceLabelValue}
+	bothLabels := map[string]string{
+		ManagedResourceLabelKey: ManagedResourceLabelValue,
+		WatchedResourceLabelKey: WatchedResourceLabelValue,
+	}
+	unrelatedLabels := map[string]string{"foo": "bar"}
+
+	tests := []struct {
+		name               string
+		labels             map[string]string
+		wantManaged        bool
+		wantManagedOrWatch bool
+	}{
+		{
+			name:               "managed label",
+			labels:             managedLabels,
+			wantManaged:        true,
+			wantManagedOrWatch: true,
+		},
+		{
+			name:               "watched label",
+			labels:             watchLabels,
+			wantManaged:        false,
+			wantManagedOrWatch: true,
+		},
+		{
+			name:               "both labels",
+			labels:             bothLabels,
+			wantManaged:        true,
+			wantManagedOrWatch: true,
+		},
+		{
+			name:               "unrelated labels",
+			labels:             unrelatedLabels,
+			wantManaged:        false,
+			wantManagedOrWatch: false,
+		},
+		{
+			name:               "nil labels",
+			labels:             nil,
+			wantManaged:        false,
+			wantManagedOrWatch: false,
+		},
+	}
+
+	managedPred := labelMatchPredicate(isManagedResource)
+	managedOrWatchedPred := labelMatchPredicate(isManagedOrWatchedResource)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			obj := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Labels: tt.labels}}
+
+			createEvt := event.CreateEvent{Object: obj}
+			if got := managedPred.Create(createEvt); got != tt.wantManaged {
+				t.Fatalf("managed Create() = %v, want %v", got, tt.wantManaged)
+			}
+			if got := managedOrWatchedPred.Create(createEvt); got != tt.wantManagedOrWatch {
+				t.Fatalf("managedOrWatched Create() = %v, want %v", got, tt.wantManagedOrWatch)
+			}
+
+			deleteEvt := event.DeleteEvent{Object: obj}
+			if got := managedPred.Delete(deleteEvt); got != tt.wantManaged {
+				t.Fatalf("managed Delete() = %v, want %v", got, tt.wantManaged)
+			}
+			if got := managedOrWatchedPred.Delete(deleteEvt); got != tt.wantManagedOrWatch {
+				t.Fatalf("managedOrWatched Delete() = %v, want %v", got, tt.wantManagedOrWatch)
+			}
+
+			genericEvt := event.GenericEvent{Object: obj}
+			if got := managedPred.Generic(genericEvt); got != tt.wantManaged {
+				t.Fatalf("managed Generic() = %v, want %v", got, tt.wantManaged)
+			}
+			if got := managedOrWatchedPred.Generic(genericEvt); got != tt.wantManagedOrWatch {
+				t.Fatalf("managedOrWatched Generic() = %v, want %v", got, tt.wantManagedOrWatch)
 			}
 		})
 	}


### PR DESCRIPTION

The managedOrWatchedResources predicate was built with predicate.NewPredicateFuncs which only inspects ObjectNew on update events. When a watched label (e.g. trustedCABundle ConfigMap) was removed externally, the event was filtered out and reconciliation never ran — breaking self-healing for watched ConfigMaps.

Extract a shared labelMatchPredicate helper that builds predicate.Funcs checking both ObjectOld and ObjectNew on updates. Consolidate the inline isManagedResource closure and the NewPredicateFuncs block into two package-level matchers (isManagedResource, isManagedOrWatchedResource) both using the new helper.

Add unit tests covering update, create, delete, and generic event behavior for both managed and watched resource predicates.

## Description

### What changed?
<!-- Summarize the changes made in this PR. -->

### Why?
<!-- What problem does this solve? What motivated this change? -->

### How?
<!-- Briefly describe the approach taken. Mention key design decisions, trade-offs, or alternatives considered. -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] CRD / API change
- [ ] Refactoring (no functional change)
- [ ] Documentation
- [ ] CI / build

## Checklist

- [ ] `make verify` passes (vet, fmt, deps, bindata, generated files, govulncheck, git diff)
- [ ] `make test` passes (unit + API integration tests)
- [ ] `make lint` passes
- [ ] New/changed CRD fields have appropriate CEL validation; add `.testsuite.yaml` tests for new CEL rules
- [ ] New managed resources added to `controllerManagedResources`, `buildCacheObjectList()`, `HasObjectChanged`, and the ordered install sequence
- [ ] No hand-edits to generated files (`bindata.go`, `zz_generated.deepcopy.go`, CRD YAML, fakes)
- [ ] Error paths use the correct error type (`IrrecoverableError` / `RetryRequiredError` / `UserConfigurationError`)

## Testing

<!-- How was this tested? Which make targets were run? For E2E, which label filter? -->

## Additional Context

<!-- Screenshots, logs, related PRs, or anything reviewers should know. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed reconciliation when ConfigMap watch labels are added or removed.
  * Improved detection of label changes across resource updates.
  * Preserved separate handling for managed resources and watched ConfigMaps.

* **Tests**
  * Added coverage for create, update, delete, and generic events, including managed, watched, combined, unrelated, and empty label scenarios.

* **Documentation**
  * Added a specification describing the issue, impact, root cause, and planned resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->