### PR TITLE
OAPE-693:Improve coverage collection reliability and add .codecov.yml

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,26 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+    patch:
+      default:
+        target: auto
+
+ignore:
+  - "vendor/**"
+  - "test/**"
+  - "hack/**"
+  - "docs/**"
+  - "bindata/**"
+  - "config/**"
+  - "bundle/**"
+  - "tools/**"
+  - "harness-evals/**"
+  - "openspec/**"
+  - ".github/**"
+  - "api/**"
+  - "pkg/operator/assets/**"
+  - "**/zz_generated*.go"
+  - "**/doc.go"
+  - "**/*.md"

--- a/hack/e2e-coverage.sh
+++ b/hack/e2e-coverage.sh
@@ -76,11 +76,35 @@ collect() {
     fi
     echo "Operator pod: ${pod}"
 
-    echo "Sending SIGTERM to operator process to flush coverage data..."
-    oc exec -n "${NAMESPACE}" "${pod}" -c manager -- /bin/sh -c 'kill -TERM 1' || true
+    local restart_count
+    restart_count=$(oc get pod "${pod}" -n "${NAMESPACE}" \
+        -o jsonpath='{.status.containerStatuses[0].restartCount}')
+    if [[ -z "${restart_count}" ]]; then
+        echo "Error: could not determine restart count for operator container" >&2
+        exit 1
+    fi
 
-    echo "Waiting for container to restart..."
-    oc wait pod/"${pod}" --for=condition=Ready=False -n "${NAMESPACE}" --timeout=30s 2>/dev/null || true
+    echo "Sending SIGTERM to operator process to flush coverage data..."
+    oc exec -n "${NAMESPACE}" "${pod}" -c manager -- /bin/sh -c 'kill -TERM 1'
+
+    echo "Waiting for container restart count to increment..."
+    local expected_count=$((restart_count + 1))
+    local current_count="${restart_count}"
+    local deadline=$((SECONDS + 120))
+    while (( SECONDS < deadline )); do
+        current_count=$(oc get pod "${pod}" -n "${NAMESPACE}" \
+            -o jsonpath='{.status.containerStatuses[0].restartCount}' 2>/dev/null || echo "0")
+        if (( current_count >= expected_count )); then
+            break
+        fi
+        sleep 2
+    done
+    if (( current_count < expected_count )); then
+        echo "Error: timed out waiting for container restart" >&2
+        exit 1
+    fi
+    echo "Container restarted (count: ${restart_count} -> ${current_count})"
+
     oc wait pod/"${pod}" --for=condition=Ready -n "${NAMESPACE}" --timeout=120s
 
     mkdir -p "${coverage_dir}"
@@ -100,6 +124,8 @@ collect() {
         echo "============================="
         echo ""
         echo "Coverage profile: ${coverage_profile} ($(wc -l < "${coverage_profile}") lines)"
+
+        rm -rf "${coverage_dir}"
 
         if [[ -n "${CODECOV_TOKEN:-}" ]]; then
             echo "Uploading to Codecov..."


### PR DESCRIPTION
## Description

### What changed?
Improves the reliability of E2E coverage collection:

Replace sleep-based waits with restart count polling for deterministic container restart detection after SIGTERM
Remove || true from oc exec kill to fail fast on SIGTERM delivery failure
Clean up raw coverage files after conversion to avoid Prow "Too many files" warning
Add .codecov.yml to exclude generated files and vendor from coverage reports

### Why?
To improve the code coverage by ignoring the auto generated files

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] CRD / API change
- [X] Refactoring (no functional change)
- [ ] Documentation
- [ ] CI / build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved end-to-end coverage collection reliability by detecting restarts, handling termination failures, and enforcing a timeout.
  - Added cleanup of temporary coverage data after collection.

- **Chores**
  - Added automated project and patch coverage targets.
  - Excluded vendor, test, tooling, documentation, generated, and other non-production files from coverage reporting.
  - Improved coverage reporting consistency by focusing results on production code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->