### PR TITLE
ESO-626: keep the base image in Containerfile and go version go.mod consistent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,13 @@ _output
 # do not apply ignore rules to anything in vendor/ dir
 !vendor/
 !vendor/**
+
+# ─── OpenSpec / local tooling (install via openspec install.sh; do not commit) ───
+# Leading / = repo root only (do not ignore harness-evals/evals/).
+/.cursor/
+/.work/
+/openspec/
+/eval-generation/
+/evals/
+/dashboard/
+# Operator-owned harness stays committed: harness-evals/{harness-docs,constitution.md,evals}/

--- a/cmd/external-secrets-operator/go.mod
+++ b/cmd/external-secrets-operator/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/external-secrets-operator/cmd/external-secrets-operator
 
-go 1.26.6
+go 1.26.0
 
 require (
 	github.com/cert-manager/cert-manager v1.18.5

--- a/images/ci/Dockerfile
+++ b/images/ci/Dockerfile
@@ -14,7 +14,7 @@ COPY . .
 
 RUN go build -tags $GO_BUILD_TAGS -o external-secrets-operator cmd/external-secrets-operator/main.go
 
-FROM registry.access.redhat.com/ubi9-minimal:9.4
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 ARG SRC_DIR=/go/src/github.com/openshift/external-secrets-operator
 COPY --from=builder $SRC_DIR/external-secrets-operator /bin/external-secrets-operator
 USER 65534:65534

--- a/images/ci/operand.Dockerfile
+++ b/images/ci/operand.Dockerfile
@@ -12,7 +12,7 @@ RUN git clone --depth 1 --branch $RELEASE_BRANCH https://github.com/openshift/ex
 RUN go mod vendor
 RUN go build -mod=vendor -tags $GO_BUILD_TAGS -o _output/external-secrets main.go
 
-FROM registry.access.redhat.com/ubi9-minimal:9.4
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 ARG SRC_DIR=/go/src/github.com/openshift/external-secrets
 COPY --from=builder $SRC_DIR/_output/external-secrets /bin/external-secrets

--- a/test/go.mod
+++ b/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/external-secrets-operator/test
 
-go 1.26.6
+go 1.26.0
 
 require (
 	github.com/aws/aws-sdk-go v1.55.8


### PR DESCRIPTION
## Description

This PR is a follow-up of https://github.com/openshift/external-secrets-operator/pull/184 created to address open comments.

### What changed?

The PR updates the go.mod to have consistent go version and Containerfiles to have the consistent base images.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] CRD / API change
- [x] Refactoring (no functional change)
- [ ] Documentation
- [ ] CI / build

## Checklist

- [x] `make verify` passes (vet, fmt, deps, bindata, generated files, govulncheck, git diff)
- [x] `make test` passes (unit + API integration tests)
- [ ] `make lint` passes
- [ ] New/changed CRD fields have appropriate CEL validation; add `.testsuite.yaml` tests for new CEL rules
- [ ] New managed resources added to `controllerManagedResources`, `buildCacheObjectList()`, `HasObjectChanged`, and the ordered install sequence
- [x] No hand-edits to generated files (`bindata.go`, `zz_generated.deepcopy.go`, CRD YAML, fakes)
- [ ] Error paths use the correct error type (`IrrecoverableError` / `RetryRequiredError` / `UserConfigurationError`)
